### PR TITLE
Add a link to Google Cloud Platform in Infrastructure doc

### DIFF
--- a/docs/01-infrastructure.md
+++ b/docs/01-infrastructure.md
@@ -1,6 +1,6 @@
 # Cloud Infrastructure Provisioning
 
-Kubernetes can be installed just about anywhere physical or virtual machines can be run. In this lab we are going to focus on Google Cloud Platform (IaaS).
+Kubernetes can be installed just about anywhere physical or virtual machines can be run. In this lab we are going to focus on [Google Cloud Platform](https://cloud.google.com/) (IaaS).
 
 This lab will walk you through provisioning the compute instances required for running a H/A Kubernetes cluster. A total of 9 virtual machines will be created.
 


### PR DESCRIPTION
Some folks may not know precicely where it is without Googling, so let's
add a link to save a step.