### PR TITLE
Provide region when creating Public IP Address

### DIFF
--- a/docs/01-infrastructure.md
+++ b/docs/01-infrastructure.md
@@ -27,6 +27,15 @@ worker2      us-central1-f  n1-standard-1               10.240.0.32  XXX.XXX.XXX
 
 To make our Kubernetes control plane remotely accessible, a public IP address will be provisioned and assigned to a Load Balancer that will sit in front of the 3 Kubernetes controllers.
 
+## Setup your Google Cloud SDK
+
+Grab the appropriate version of the [Google Cloud SDK](https://cloud.google.com/sdk/docs/).
+
+```
+gcloud config set compute/region us-central1
+gcloud config set compute/zone us-central1-f
+```
+
 ## Create a Custom Network
 
 ```
@@ -43,8 +52,7 @@ Create a subnet for the Kubernetes cluster:
 ```
 gcloud compute networks subnets create kubernetes \
   --network kubernetes \
-  --range 10.240.0.0/24 \
-  --region us-central1
+  --range 10.240.0.0/24
 ```
 
 ```
@@ -116,7 +124,7 @@ kubernetes-allow-ssh         kubernetes  0.0.0.0/0       tcp:22
 Create a public IP address that will be used by remote clients to connect to the Kubernetes control plane:
 
 ```
-gcloud compute addresses create kubernetes --region=us-central1
+gcloud compute addresses create kubernetes
 ```
 
 ```

--- a/docs/01-infrastructure.md
+++ b/docs/01-infrastructure.md
@@ -116,7 +116,7 @@ kubernetes-allow-ssh         kubernetes  0.0.0.0/0       tcp:22
 Create a public IP address that will be used by remote clients to connect to the Kubernetes control plane:
 
 ```
-gcloud compute addresses create kubernetes
+gcloud compute addresses create kubernetes --region=us-central1
 ```
 
 ```


### PR DESCRIPTION
This avoids the prompt for region and follows the precedent set by the subnet creation
