### PR TITLE
Fixes for "missing" zone information

### DIFF
--- a/docs/02-certificate-authority.md
+++ b/docs/02-certificate-authority.md
@@ -193,13 +193,13 @@ openssl x509 -in kubernetes.pem -text -noout
 ## Copy TLS Certs
 
 ```
-gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem controller0:~/
-gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem controller1:~/
-gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem controller2:~/
-gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem etcd0:~/
-gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem etcd1:~/
-gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem etcd2:~/
-gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem worker0:~/
-gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem worker1:~/
-gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem worker2:~/
+gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem controller0:~/ --zone us-central1-f
+gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem controller1:~/ --zone us-central1-f
+gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem controller2:~/ --zone us-central1-f
+gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem etcd0:~/ --zone us-central1-f
+gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem etcd1:~/ --zone us-central1-f
+gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem etcd2:~/ --zone us-central1-f
+gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem worker0:~/ --zone us-central1-f
+gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem worker1:~/ --zone us-central1-f
+gcloud compute copy-files ca.pem kubernetes-key.pem kubernetes.pem worker2:~/ --zone us-central1-f
 ```

--- a/docs/04-kubernetes-controller.md
+++ b/docs/04-kubernetes-controller.md
@@ -287,7 +287,8 @@ gcloud compute target-pools create kubernetes-pool \
 
 ```
 gcloud compute target-pools add-instances kubernetes-pool \
-  --instances controller0,controller1,controller2
+  --instances controller0,controller1,controller2 \
+  --zone us-central1-f
 ```
 
 ```

--- a/docs/09-smoke-test.md
+++ b/docs/09-smoke-test.md
@@ -48,7 +48,8 @@ Grab the `EXTERNAL_IP` for one of the worker nodes:
 
 ```
 export NODE_PUBLIC_IP=$(gcloud compute instances describe worker0 \
-  --format 'value(networkInterfaces[0].accessConfigs[0].natIP)')
+  --format 'value(networkInterfaces[0].accessConfigs[0].natIP)' \
+  --zone us-central1-f)
 ```
 
 Test the nginx service using cURL:


### PR DESCRIPTION
If you pick a non-default zone for your nodes, like I did, you're going to have a bad time trying to figure out why gcloud can't find your instances. I think several of the gcloud commands look for a default zone `us-central1-c`.

Adding the `--zone us-central1-f` would match what your documentation shows.

This is just one way of solving the issue, but it worked for me.

Thank you for this guide! It's been fantastic for de-mystifying the components needed and jumping in responsibly!