### PR TITLE
Streamline systemd service file creation

### DIFF
--- a/docs/03-etcd.md
+++ b/docs/03-etcd.md
@@ -61,36 +61,6 @@ Create the etcd systemd unit file:
 
 
 ```
-cat > etcd.service <<"EOF"
-[Unit]
-Description=etcd
-Documentation=https://github.com/coreos
-
-[Service]
-ExecStart=/usr/bin/etcd --name ETCD_NAME \
-  --cert-file=/etc/etcd/kubernetes.pem \
-  --key-file=/etc/etcd/kubernetes-key.pem \
-  --peer-cert-file=/etc/etcd/kubernetes.pem \
-  --peer-key-file=/etc/etcd/kubernetes-key.pem \
-  --trusted-ca-file=/etc/etcd/ca.pem \
-  --peer-trusted-ca-file=/etc/etcd/ca.pem \
-  --initial-advertise-peer-urls https://INTERNAL_IP:2380 \
-  --listen-peer-urls https://INTERNAL_IP:2380 \
-  --listen-client-urls https://INTERNAL_IP:2379,http://127.0.0.1:2379 \
-  --advertise-client-urls https://INTERNAL_IP:2379 \
-  --initial-cluster-token etcd-cluster-0 \
-  --initial-cluster etcd0=https://10.240.0.10:2380,etcd1=https://10.240.0.11:2380,etcd2=https://10.240.0.12:2380 \
-  --initial-cluster-state new \
-  --data-dir=/var/lib/etcd
-Restart=on-failure
-RestartSec=5
-
-[Install]
-WantedBy=multi-user.target
-EOF
-```
-
-```
 export INTERNAL_IP=$(curl -s -H "Metadata-Flavor: Google" \
   http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip)
 ```
@@ -99,16 +69,33 @@ export INTERNAL_IP=$(curl -s -H "Metadata-Flavor: Google" \
 export ETCD_NAME=$(hostname -s)
 ```
 
-```
-sed -i s/INTERNAL_IP/$INTERNAL_IP/g etcd.service
-```
 
 ```
-sed -i s/ETCD_NAME/$ETCD_NAME/g etcd.service
-```
+sudo sh -c "echo '[Unit]
+Description=etcd
+Documentation=https://github.com/coreos
 
-```
-sudo mv etcd.service /etc/systemd/system/
+[Service]
+ExecStart=/usr/bin/etcd --name $ETCD_NAME \\
+  --cert-file=/etc/etcd/kubernetes.pem \\
+  --key-file=/etc/etcd/kubernetes-key.pem \\
+  --peer-cert-file=/etc/etcd/kubernetes.pem \\
+  --peer-key-file=/etc/etcd/kubernetes-key.pem \\
+  --trusted-ca-file=/etc/etcd/ca.pem \\
+  --peer-trusted-ca-file=/etc/etcd/ca.pem \\
+  --initial-advertise-peer-urls https://$INTERNAL_IP:2380 \\
+  --listen-peer-urls https://$INTERNAL_IP:2380 \\
+  --listen-client-urls https://$INTERNAL_IP:2379,http://127.0.0.1:2379 \\
+  --advertise-client-urls https://$INTERNAL_IP:2379 \\
+  --initial-cluster-token etcd-cluster-0 \\
+  --initial-cluster etcd0=https://10.240.0.10:2380,etcd1=https://10.240.0.11:2380,etcd2=https://10.240.0.12:2380 \\
+  --initial-cluster-state new \\
+  --data-dir=/var/lib/etcd
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target' > /etc/systemd/system/etcd.service"
 ```
 
 Start etcd:

--- a/docs/04-kubernetes-controller.md
+++ b/docs/04-kubernetes-controller.md
@@ -113,48 +113,41 @@ export INTERNAL_IP=$(curl -s -H "Metadata-Flavor: Google" \
 Create the systemd unit file:
 
 ```
-cat > kube-apiserver.service <<"EOF"
-[Unit]
+sudo sh -c "echo '[Unit]
 Description=Kubernetes API Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
 [Service]
-ExecStart=/usr/bin/kube-apiserver \
-  --admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
-  --advertise-address=INTERNAL_IP \
-  --allow-privileged=true \
-  --apiserver-count=3 \
-  --authorization-mode=ABAC \
-  --authorization-policy-file=/var/lib/kubernetes/authorization-policy.jsonl \
-  --bind-address=0.0.0.0 \
-  --enable-swagger-ui=true \
-  --etcd-cafile=/var/lib/kubernetes/ca.pem \
-  --insecure-bind-address=0.0.0.0 \
-  --kubelet-certificate-authority=/var/lib/kubernetes/ca.pem \
-  --etcd-servers=https://10.240.0.10:2379,https://10.240.0.11:2379,https://10.240.0.12:2379 \
-  --service-account-key-file=/var/lib/kubernetes/kubernetes-key.pem \
-  --service-cluster-ip-range=10.32.0.0/24 \
-  --service-node-port-range=30000-32767 \
-  --tls-cert-file=/var/lib/kubernetes/kubernetes.pem \
-  --tls-private-key-file=/var/lib/kubernetes/kubernetes-key.pem \
-  --token-auth-file=/var/lib/kubernetes/token.csv \
+ExecStart=/usr/bin/kube-apiserver \\
+  --admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \\
+  --advertise-address=$INTERNAL_IP \\
+  --allow-privileged=true \\
+  --apiserver-count=3 \\
+  --authorization-mode=ABAC \\
+  --authorization-policy-file=/var/lib/kubernetes/authorization-policy.jsonl \\
+  --bind-address=0.0.0.0 \\
+  --enable-swagger-ui=true \\
+  --etcd-cafile=/var/lib/kubernetes/ca.pem \\
+  --insecure-bind-address=0.0.0.0 \\
+  --kubelet-certificate-authority=/var/lib/kubernetes/ca.pem \\
+  --etcd-servers=https://10.240.0.10:2379,https://10.240.0.11:2379,https://10.240.0.12:2379 \\
+  --service-account-key-file=/var/lib/kubernetes/kubernetes-key.pem \\
+  --service-cluster-ip-range=10.32.0.0/24 \\
+  --service-node-port-range=30000-32767 \\
+  --tls-cert-file=/var/lib/kubernetes/kubernetes.pem \\
+  --tls-private-key-file=/var/lib/kubernetes/kubernetes-key.pem \\
+  --token-auth-file=/var/lib/kubernetes/token.csv \\
   --v=2
 Restart=on-failure
 RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
-EOF
-```
-
-```
-sed -i s/INTERNAL_IP/$INTERNAL_IP/g kube-apiserver.service
+WantedBy=multi-user.target' > /etc/systemd/system/kube-apiserver.service"
 ```
 
 ```
 sudo mv kube-apiserver.service /etc/systemd/system/
 ```
-
 
 ```
 sudo systemctl daemon-reload
@@ -169,38 +162,27 @@ sudo systemctl status kube-apiserver --no-pager
 ### Kubernetes Controller Manager
 
 ```
-cat > kube-controller-manager.service <<"EOF"
-[Unit]
+sudo su -c "echo '[Unit]
 Description=Kubernetes Controller Manager
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
 [Service]
-ExecStart=/usr/bin/kube-controller-manager \
-  --allocate-node-cidrs=true \
-  --cluster-cidr=10.200.0.0/16 \
-  --cluster-name=kubernetes \
-  --leader-elect=true \
-  --master=http://INTERNAL_IP:8080 \
-  --root-ca-file=/var/lib/kubernetes/ca.pem \
-  --service-account-private-key-file=/var/lib/kubernetes/kubernetes-key.pem \
-  --service-cluster-ip-range=10.32.0.0/24 \
+ExecStart=/usr/bin/kube-controller-manager \\
+  --allocate-node-cidrs=true \\
+  --cluster-cidr=10.200.0.0/16 \\
+  --cluster-name=kubernetes \\
+  --leader-elect=true \\
+  --master=http://$INTERNAL_IP:8080 \\
+  --root-ca-file=/var/lib/kubernetes/ca.pem \\
+  --service-account-private-key-file=/var/lib/kubernetes/kubernetes-key.pem \\
+  --service-cluster-ip-range=10.32.0.0/24 \\
   --v=2
 Restart=on-failure
 RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
-EOF
+WantedBy=multi-user.target' > /etc/systemd/system/kube-controller-manager.service"
 ```
-
-```
-sed -i s/INTERNAL_IP/$INTERNAL_IP/g kube-controller-manager.service
-```
-
-```
-sudo mv kube-controller-manager.service /etc/systemd/system/
-```
-
 
 ```
 sudo systemctl daemon-reload
@@ -215,30 +197,20 @@ sudo systemctl status kube-controller-manager --no-pager
 ### Kubernetes Scheduler
 
 ```
-cat > kube-scheduler.service <<"EOF"
-[Unit]
+sudo sh -c "echo '[Unit]
 Description=Kubernetes Scheduler
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
 [Service]
-ExecStart=/usr/bin/kube-scheduler \
-  --leader-elect=true \
-  --master=http://INTERNAL_IP:8080 \
+ExecStart=/usr/bin/kube-scheduler \\
+  --leader-elect=true \\
+  --master=http://$INTERNAL_IP:8080 \\
   --v=2
 Restart=on-failure
 RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
-EOF
-```
-
-```
-sed -i s/INTERNAL_IP/$INTERNAL_IP/g kube-scheduler.service
-```
-
-```
-sudo mv kube-scheduler.service /etc/systemd/system/
+WantedBy=multi-user.target' > /etc/systemd/system/kube-scheduler.service"
 ```
 
 ```


### PR DESCRIPTION
We can remove a few sed and mv commands by using the same invocation as in [docs/05-kubernetes-worker.md](docs/05-kubernetes-worker.md) (`sudo sh -c "echo '...' > /etc/systemd/..."`) except here using some variable interpolation.
