### PR TITLE
Add command to set the default zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ GCP
 
 ```
 gcloud config set compute/region us-central1
+gcloud config set compute/zone us-central1-a
 ```
 
 AWS


### PR DESCRIPTION
There's no assumption about the default zone in these instructions, so many commands require interactive prompts to set the zone. This fixes that by setting the default zone up front.
