### PR TITLE
jq -j is not a valid option. I think the author meant jq -r

### DIFF
--- a/docs/02-certificate-authority.md
+++ b/docs/02-certificate-authority.md
@@ -237,7 +237,7 @@ The following command will:
 for host in ${KUBERNETES_HOSTS[*]}; do
   PUBLIC_IP_ADDRESS=$(aws ec2 describe-instances \
     --filters "Name=tag:Name,Values=${host}" | \
-    jq -j '.Reservations[].Instances[].PublicIpAddress')
+    jq -r '.Reservations[].Instances[].PublicIpAddress')
   scp ca.pem kubernetes-key.pem kubernetes.pem \
     ubuntu@${PUBLIC_IP_ADDRESS}:~/
 done


### PR DESCRIPTION
Hi Kelsey,

I thought it may be a typo to use "jq -j" instead of "jq -r". Or I am missing something here. Please review.

Thanks,
Gopi