### PR TITLE
Fix typo

### DIFF
--- a/docs/03-etcd.md
+++ b/docs/03-etcd.md
@@ -9,7 +9,7 @@ In this lab you will bootstrap a 3 node etcd cluster. The following virtual mach
 ## Why
 
 All Kubernetes components are stateless which greatly simplifies managing a Kubernetes cluster. All state is stored
-in etcd, which is a database and must be treated special. etcd is being run on a dedicated set of machines for the 
+in etcd, which is a database and must be treated specially. etcd is being run on a dedicated set of machines for the 
 following reasons:
 
 * The etcd lifecycle is not tied to Kubernetes. We should be able to upgrade etcd independently of Kubernetes.


### PR DESCRIPTION
Changes: `All state is stored in etcd, which is a database and must be treated special.`  ->  `All state is stored in etcd, which is a database and must be treated specially.` 