### PR TITLE
GCP: Add command to specify default zone before VM provision

### DIFF
--- a/docs/01-infrastructure-gcp.md
+++ b/docs/01-infrastructure-gcp.md
@@ -140,6 +140,12 @@ All the VMs in this lab will be provisioned using Ubuntu 16.04 mainly because it
 
 ### Virtual Machines
 
+To avoid specifying the zone for each VM, you may wish to specify a default zone.
+
+```
+gcloud config set compute/zone us-central1-a
+```
+
 #### etcd
 
 ```


### PR DESCRIPTION
Thanks for this wonderful guide! I'm new to Kubernetes and decided to give GCP a spin (the free $300 worth of compute doesn't hurt either :). During the VM provision stage I was having to specify the default zone each time so I added this line about specifying the default compute zone.