### PR TITLE
hostname in Kubernetes TLS Certificate

### DIFF
--- a/docs/02-certificate-authority.md
+++ b/docs/02-certificate-authority.md
@@ -187,6 +187,7 @@ cfssl gencert \
   -ca-key=ca-key.pem \
   -config=ca-config.json \
   -profile=kubernetes \
+  -hostname=hosts \
   kubernetes-csr.json | cfssljson -bare kubernetes
 ```
 


### PR DESCRIPTION
Got the following warning while generating TLS Cert
> `This certificate lacks a "hosts" field`

Added `-hostname` flag. Please review
