### PR TITLE
adding filter to `aws describe-instances` command to filter by the vpc-id

### DIFF
--- a/docs/01-infrastructure-aws.md
+++ b/docs/01-infrastructure-aws.md
@@ -452,7 +452,7 @@ aws ec2 create-tags \
 
 ```
 aws ec2 describe-instances \
-  --filters "Name=instance-state-name,Values=running" | \
+  --filters "Name=instance-state-name,Values=running" "Name=vpc-id,Values=${VPC_ID}" | \
   jq -j '.Reservations[].Instances[] | .InstanceId, "  ", .Placement.AvailabilityZone, "  ", .PrivateIpAddress, "  ", .PublicIpAddress, "\n"'
 ```
 ```


### PR DESCRIPTION
If there's another vpc or other running instances this only shows the one we care about.
