### PR TITLE
Adjust the ingress rule to allow all outgoing traffic

### DIFF
--- a/docs/01-infrastructure-aws.md
+++ b/docs/01-infrastructure-aws.md
@@ -141,7 +141,7 @@ aws ec2 create-tags \
 ```
 
 ```
-aws ec2 authorize-security-group-ingress \
+aws ec2 authorize-security-group-egress \
   --group-id ${SECURITY_GROUP_ID} \
   --protocol all
 ```


### PR DESCRIPTION
Hi,
thanks for the great write up. I'm pretty sure that the listings for AWS contain a little mistake. When it comes to the security group setup, there are a bunch of ingress rules but no egress rule. In fact the first ingress rule is very open which would not require and additional ones. Therefore I assume the first rule was actually supposed to be a egress rule.

This PR changes the listing, so that all outgoing traffic is allowed.

Cheers
