### PR TITLE
Replace `jq -j` with `jq -r`

### DIFF
--- a/docs/01-infrastructure-aws.md
+++ b/docs/01-infrastructure-aws.md
@@ -237,7 +237,7 @@ aws iam put-role-policy \
 
 ```
 aws iam create-instance-profile \
-  --instance-profile-name kubernetes 
+  --instance-profile-name kubernetes
 ```
 
 ```
@@ -266,7 +266,7 @@ chmod 600 ~/.ssh/kubernetes_the_hard_way
 ```
 
 ```
-ssh-add ~/.ssh/kubernetes_the_hard_way 
+ssh-add ~/.ssh/kubernetes_the_hard_way
 ```
 
 #### SSH Access
@@ -276,7 +276,7 @@ Once the virtual machines are created you'll be able to login into each machine 
 ```
 WORKER_0_PUBLIC_IP_ADDRESS=$(aws ec2 describe-instances \
     --filters "Name=tag:Name,Values=worker0" | \
-    jq -j '.Reservations[].Instances[].PublicIpAddress')
+    jq -r '.Reservations[].Instances[].PublicIpAddress')
 ```
 
 > The instance public IP address can also be obtained from the EC2 console. Each node will be tagged with a unique name.
@@ -313,7 +313,7 @@ aws ec2 modify-instance-attribute \
 aws ec2 create-tags \
   --resources ${CONTROLLER_0_INSTANCE_ID} \
   --tags Key=Name,Value=controller0
-``` 
+```
 
 ```
 CONTROLLER_1_INSTANCE_ID=$(aws ec2 run-instances \
@@ -339,7 +339,7 @@ aws ec2 modify-instance-attribute \
 aws ec2 create-tags \
   --resources ${CONTROLLER_1_INSTANCE_ID} \
   --tags Key=Name,Value=controller1
-``` 
+```
 
 ```
 CONTROLLER_2_INSTANCE_ID=$(aws ec2 run-instances \
@@ -365,7 +365,7 @@ aws ec2 modify-instance-attribute \
 aws ec2 create-tags \
   --resources ${CONTROLLER_2_INSTANCE_ID} \
   --tags Key=Name,Value=controller2
-``` 
+```
 
 #### Kubernetes Workers
 
@@ -453,7 +453,7 @@ aws ec2 create-tags \
 ```
 aws ec2 describe-instances \
   --filters "Name=instance-state-name,Values=running" | \
-  jq -j '.Reservations[].Instances[] | .InstanceId, "  ", .Placement.AvailabilityZone, "  ", .PrivateIpAddress, "  ", .PublicIpAddress, "\n"'
+  jq -r '.Reservations[].Instances[] | .InstanceId, "  ", .Placement.AvailabilityZone, "  ", .PrivateIpAddress, "  ", .PublicIpAddress, "\n"'
 ```
 ```
 i-ae714f73  us-west-2c  10.240.0.11  XX.XX.XX.XXX

--- a/docs/07-network.md
+++ b/docs/07-network.md
@@ -26,7 +26,7 @@ Based on the above configuration each node will receive a `/24` subnet. For exam
 10.200.1.0/24
 10.200.2.0/24
 ...
-``` 
+```
 
 ## Get the Routing Table
 
@@ -42,9 +42,9 @@ kubectl get nodes \
 Output:
 
 ```
-10.240.0.20 10.200.0.0/24 
-10.240.0.21 10.200.1.0/24 
-10.240.0.22 10.200.2.0/24 
+10.240.0.20 10.200.0.0/24
+10.240.0.21 10.200.1.0/24
+10.240.0.22 10.200.2.0/24
 ```
 
 ## Create Routes
@@ -83,7 +83,7 @@ ROUTE_TABLE_ID=$(aws ec2 describe-route-tables \
 ```
 WORKER_0_INSTANCE_ID=$(aws ec2 describe-instances \
   --filters "Name=tag:Name,Values=worker0" | \
-  jq -j '.Reservations[].Instances[].InstanceId')
+  jq -r '.Reservations[].Instances[].InstanceId')
 ```
 
 ```
@@ -96,7 +96,7 @@ aws ec2 create-route \
 ```
 WORKER_1_INSTANCE_ID=$(aws ec2 describe-instances \
   --filters "Name=tag:Name,Values=worker1" | \
-  jq -j '.Reservations[].Instances[].InstanceId')
+  jq -r '.Reservations[].Instances[].InstanceId')
 ```
 
 ```
@@ -109,7 +109,7 @@ aws ec2 create-route \
 ```
 WORKER_2_INSTANCE_ID=$(aws ec2 describe-instances \
   --filters "Name=tag:Name,Values=worker2" | \
-  jq -j '.Reservations[].Instances[].InstanceId')
+  jq -r '.Reservations[].Instances[].InstanceId')
 ```
 
 ```

--- a/docs/09-smoke-test.md
+++ b/docs/09-smoke-test.md
@@ -76,7 +76,7 @@ Grab the `EXTERNAL_IP` for one of the worker nodes:
 ```
 NODE_PUBLIC_IP=$(aws ec2 describe-instances \
   --filters "Name=tag:Name,Values=worker0" | \
-  jq -j '.Reservations[].Instances[].PublicIpAddress')
+  jq -r '.Reservations[].Instances[].PublicIpAddress')
 ```
 
 ---

--- a/docs/10-cleanup.md
+++ b/docs/10-cleanup.md
@@ -68,7 +68,7 @@ KUBERNETES_HOSTS=(controller0 controller1 controller2 worker0 worker1 worker2)
 for host in ${KUBERNETES_HOSTS[*]}; do
   INSTANCE_ID=$(aws ec2 describe-instances \
     --filters "Name=tag:Name,Values=${host}" | \
-    jq -j '.Reservations[].Instances[].InstanceId')
+    jq -r '.Reservations[].Instances[].InstanceId')
   aws ec2 terminate-instances --instance-ids ${INSTANCE_ID}
 done
 ```


### PR DESCRIPTION
We kept getting errors about unknown flags when using `jq -j` but `jq -r` seems to do the trick.