### PR TITLE
Correction in argument assignment

### DIFF
--- a/docs/06-kubectl.md
+++ b/docs/06-kubectl.md
@@ -59,7 +59,7 @@ kubectl config set-cluster kubernetes-the-hard-way \
 ```
 
 ```
-kubectl config set-credentials admin --token chAng3m3
+kubectl config set-credentials admin --token=chAng3m3
 ```
 
 ```


### PR DESCRIPTION
As of kubectl v0.14.1, the argument must be assigned using an equal
sign otherwise a "flag needs an argument: --token" error is thrown.