### PR TITLE
Make the AWS region configurable

### DIFF
--- a/docs/02-certificate-authority.md
+++ b/docs/02-certificate-authority.md
@@ -235,7 +235,7 @@ for host in ${KUBERNETES_HOSTS[*]}; do
   PUBLIC_IP_ADDRESS=$(aws ec2 describe-instances \
     --filters "Name=tag:Name,Values=${host}" | \
     jq -r '.Reservations[].Instances[].PublicIpAddress')
-  scp ca.pem kubernetes-key.pem kubernetes.pem \
+  scp -o "StrictHostKeyChecking no" ca.pem kubernetes-key.pem kubernetes.pem \
     ubuntu@${PUBLIC_IP_ADDRESS}:~/
 done
 ```


### PR DESCRIPTION
Major change is to allow setting the AWS region when building out the infrastructure. Also updated the "scp" command to turn StrictHostKeyChecking off.