### PR TITLE
Replaced deprecated flag --health-check

### DIFF
--- a/docs/04-kubernetes-controller.md
+++ b/docs/04-kubernetes-controller.md
@@ -313,7 +313,7 @@ gcloud compute http-health-checks create kube-apiserver-check \
 
 ```
 gcloud compute target-pools create kubernetes-pool \
-  --health-check kube-apiserver-check
+  --http-health-check=kube-apiserver-check
 ```
 
 ```


### PR DESCRIPTION
Replaced deprecated flag --health-check with the new
 --http-health-check=kube-apiserver-check

Not a big change, but removes this:
WARNING: The --health-check flag is deprecated. Use equivalent --http-health-check=kube-apiserver-check flag.
