### PR TITLE
Add Node details to run client commands from

### DIFF
--- a/docs/04-kubernetes-controller.md
+++ b/docs/04-kubernetes-controller.md
@@ -176,6 +176,7 @@ RestartSec=5
 WantedBy=multi-user.target
 EOF
 ```
+- Note: If you are deploying this on AWS then you should add ``--cloud-provider=aws`` in the ``kube-apiserver.service`` unit file's [service] section. If you are adding this before ``--v=2`` line, remember to add ``\`` character at the end   
 
 ```
 sed -i s/INTERNAL_IP/$INTERNAL_IP/g kube-apiserver.service
@@ -222,6 +223,8 @@ RestartSec=5
 WantedBy=multi-user.target
 EOF
 ```
+- Note: If you are deploying this on AWS then you should add ``--cloud-provider=aws`` in the ``kube-controller-manager.service`` unit file's [service] section. If you are adding this before ``--v=2`` line , remember to add ``\`` character at the end.
+
 
 ```
 sed -i s/INTERNAL_IP/$INTERNAL_IP/g kube-controller-manager.service

--- a/docs/06-kubectl.md
+++ b/docs/06-kubectl.md
@@ -1,5 +1,7 @@
 # Configuring the Kubernetes Client - Remote Access
 
+Run the following commands from the machine which will be your Kubernetes Client
+
 ## Download and Install kubectl
 
 ### OS X


### PR DESCRIPTION
docs/06.kubectl.md does not instruct from which node those commands must be run.
The previous modules does explain that. For a newbie its helpful to tell them
from which node they must run commands of doc/06-kubectl.md.

This PR has a minor update about that information.