### PR TITLE
Add firewall rule to allow pods access to PodCIDR

### DIFF
--- a/docs/01-infrastructure-gcp.md
+++ b/docs/01-infrastructure-gcp.md
@@ -64,6 +64,13 @@ gcloud compute firewall-rules create kubernetes-allow-internal \
 ```
 
 ```
+gcloud compute firewall-rules create kubernetes-allow-internal-podcidr \
+    --allow tcp:0-65535,udp:0-65535,icmp \
+    --network kubernetes \
+    --source-ranges 10.200.0.0/16
+```
+
+```
 gcloud compute firewall-rules create kubernetes-allow-rdp \
   --allow tcp:3389 \
   --network kubernetes \


### PR DESCRIPTION
This fixes issue #88 to allow pods access to PodCIDR such as the case of
DNS. When pods come up with an IP address in the cluster CIDR range,
they cannot access kubedns without a firewall rule to enable it. This
would also prevent pods from accessing each other depending on the
application.