### PR TITLE
Typo fix: TLC => TLS

### DIFF
--- a/docs/04-kubernetes-controller.md
+++ b/docs/04-kubernetes-controller.md
@@ -29,7 +29,7 @@ Run the following commands on `controller0`, `controller1`, `controller2`:
 
 ### TLS Certificates
 
-The TLS certificates created in the [Setting up a CA and TLS Cert Generation](02-certificate-authority.md) lab will be used to secure communication between the Kubernetes API server and Kubernetes clients such as `kubectl` and the `kubelet` agent. The TLS certificates will also be used to authenticate the Kubernetes API server to etcd via TLC client auth.
+The TLS certificates created in the [Setting up a CA and TLS Cert Generation](02-certificate-authority.md) lab will be used to secure communication between the Kubernetes API server and Kubernetes clients such as `kubectl` and the `kubelet` agent. The TLS certificates will also be used to authenticate the Kubernetes API server to etcd via TLS client auth.
 
 Copy the TLS certificates to the Kubernetes configuration directory:
 


### PR DESCRIPTION
Tender Loving Care auth is deprecated in Kube 1.4 ;)