### PR TITLE
Update kubectl to 1.6.0 release

### DIFF
--- a/docs/03-auth-configs.md
+++ b/docs/03-auth-configs.md
@@ -9,7 +9,7 @@ The kubectl client will be used to generate kubeconfig files which will be consu
 ### OS X
 
 ```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.6.0-rc.1/bin/darwin/amd64/kubectl
+wget https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/darwin/amd64/kubectl
 chmod +x kubectl
 sudo mv kubectl /usr/local/bin
 ```
@@ -17,7 +17,7 @@ sudo mv kubectl /usr/local/bin
 ### Linux
 
 ```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.6.0-rc.1/bin/linux/amd64/kubectl
+wget https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kubectl
 chmod +x kubectl
 sudo mv kubectl /usr/local/bin
 ```


### PR DESCRIPTION
Kubectl 1.6.0 has now been fully released https://github.com/kubernetes/kubernetes/releases/tag/v1.6.0