### PR TITLE
Add Authentication to etcd configuration

### DIFF
--- a/docs/04-etcd.md
+++ b/docs/04-etcd.md
@@ -91,6 +91,8 @@ ExecStart=/usr/bin/etcd \\
   --peer-key-file=/etc/etcd/kubernetes-key.pem \\
   --trusted-ca-file=/etc/etcd/ca.pem \\
   --peer-trusted-ca-file=/etc/etcd/ca.pem \\
+  --peer-client-cert-auth \\
+  --client-cert-auth \\
   --initial-advertise-peer-urls https://${INTERNAL_IP}:2380 \\
   --listen-peer-urls https://${INTERNAL_IP}:2380 \\
   --listen-client-urls https://${INTERNAL_IP}:2379,http://127.0.0.1:2379 \\


### PR DESCRIPTION
Added two flags needed to activate client and peer authentication in etcd

From https://coreos.com/etcd/docs/latest/op-guide/security.html these two flags are needed to get etcd to implement authentication for clients and peers