### PR TITLE
fixes #158: remove redundant --api-servers argument in systemd config

### DIFF
--- a/docs/06-kubernetes-worker.md
+++ b/docs/06-kubernetes-worker.md
@@ -173,7 +173,6 @@ Requires=docker.service
 
 [Service]
 ExecStart=/usr/bin/kubelet \\
-  --api-servers=${API_SERVERS} \\
   --allow-privileged=true \\
   --cluster-dns=10.32.0.10 \\
   --cluster-domain=cluster.local \\


### PR DESCRIPTION
The `bootstrap.kubeconfig` contains the api server location so this argument is not required anymore.