### PR TITLE
Update 05-kubernetes-controller.md

### DIFF
--- a/docs/05-kubernetes-controller.md
+++ b/docs/05-kubernetes-controller.md
@@ -286,7 +286,8 @@ gcloud compute http-health-checks create kube-apiserver-health-check \
 
 ```
 gcloud compute target-pools create kubernetes-target-pool \
-  --http-health-check=kube-apiserver-health-check
+  --http-health-check=kube-apiserver-health-check \
+  --region us-central1
 ```
 
 ```


### PR DESCRIPTION
Unless the region is explicitly passed, I get the error:
```
ERROR: (gcloud.compute.target-pools.create) Some requests did not succeed:
 - Invalid value for field 'region': 'us-central1-b'. Unknown region.
```