### PR TITLE
Use gcloud compute scp instead of copy-files

### DIFF
--- a/docs/02-certificate-authority.md
+++ b/docs/02-certificate-authority.md
@@ -267,16 +267,16 @@ kubernetes.pem
 
 Set the list of Kubernetes hosts where the certs should be copied to:
 
-The following commands will copy the TLS certificates and keys to each Kubernetes host using the `gcloud compute copy-files` command.
+The following commands will copy the TLS certificates and keys to each Kubernetes host using the `gcloud compute scp` command.
 
 ```
 for host in worker0 worker1 worker2; do
-  gcloud compute copy-files ca.pem kube-proxy.pem kube-proxy-key.pem ${host}:~/
+  gcloud compute scp ca.pem kube-proxy.pem kube-proxy-key.pem ${host}:~/
 done
 ```
 
 ```
 for host in controller0 controller1 controller2; do
-  gcloud compute copy-files ca.pem ca-key.pem kubernetes-key.pem kubernetes.pem ${host}:~/
+  gcloud compute scp ca.pem ca-key.pem kubernetes-key.pem kubernetes.pem ${host}:~/
 done
 ```

--- a/docs/03-auth-configs.md
+++ b/docs/03-auth-configs.md
@@ -34,7 +34,7 @@ The other components, mainly the `scheduler` and `controller manager`, access th
 
 ### Create the TLS Bootstrap Token
 
-This section will walk you through the creation of a TLS bootstrap token that will be used to [bootstrap TLS client certificates for kubelets](https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/). 
+This section will walk you through the creation of a TLS bootstrap token that will be used to [bootstrap TLS client certificates for kubelets](https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/).
 
 Generate a token:
 
@@ -54,7 +54,7 @@ Distribute the bootstrap token file to each controller node:
 
 ```
 for host in controller0 controller1 controller2; do
-  gcloud compute copy-files token.csv ${host}:~/
+  gcloud compute scp token.csv ${host}:~/
 done
 ```
 
@@ -135,6 +135,6 @@ kubectl config use-context default --kubeconfig=kube-proxy.kubeconfig
 
 ```
 for host in worker0 worker1 worker2; do
-  gcloud compute copy-files bootstrap.kubeconfig kube-proxy.kubeconfig ${host}:~/
+  gcloud compute scp bootstrap.kubeconfig kube-proxy.kubeconfig ${host}:~/
 done
 ```


### PR DESCRIPTION
Updating to use `gcloud compute scp` due to following warning:
> WARNING: `gcloud compute copy-files` is deprecated.  Please use `gcloud compute scp` instead.  Note that `gcloud compute scp` does not have recursive copy on by default.  To turn on recursion, use the `--recurse` flag.
