### PR TITLE
update 'scp' to 'copy-files'

### DIFF
--- a/docs/02-certificate-authority.md
+++ b/docs/02-certificate-authority.md
@@ -271,12 +271,12 @@ The following commands will copy the TLS certificates and keys to each Kubernete
 
 ```
 for host in worker0 worker1 worker2; do
-  gcloud compute scp ca.pem kube-proxy.pem kube-proxy-key.pem ${host}:~/
+  gcloud compute copy-files ca.pem kube-proxy.pem kube-proxy-key.pem ${host}:~/
 done
 ```
 
 ```
 for host in controller0 controller1 controller2; do
-  gcloud compute scp ca.pem ca-key.pem kubernetes-key.pem kubernetes.pem ${host}:~/
+  gcloud compute copy-files ca.pem ca-key.pem kubernetes-key.pem kubernetes.pem ${host}:~/
 done
 ```


### PR DESCRIPTION
gcloud --version
Google Cloud SDK 154.0.1
app-engine-python 1.9.52
bq 2.0.24
cloud-datastore-emulator 1.2.1
core 2017.05.04
docker-credential-gcr
gcloud
gsutil 4.25
kubectl

$ for host in worker0 worker1 worker2; do
>   gcloud compute scp ca.pem kube-proxy.pem kube-proxy-key.pem ${host}:~/
> done
ERROR: (gcloud.compute) Invalid choice: 'scp'.

for host in worker0 worker1 worker2; do   gcloud compute copy-files ca.pem kube-proxy.pem kube-proxy-key.pem ${host}:~/; done
Warning: Permanently added 'compute.6461459711323000154' (ECDSA) to the list of known hosts.
ca.pem                                                                                 100% 1367     1.3KB/s   00:00
kube-proxy.pem                                                                         100% 1428     1.4KB/s   00:00
kube-proxy-key.pem                                                                     100% 1679     1.6KB/s   00:00
Warning: Permanently added 'compute.601335813592567078' (ECDSA) to the list of known hosts.
ca.pem                                                                                 100% 1367     1.3KB/s   00:00
kube-proxy.pem                                                                         100% 1428     1.4KB/s   00:00
kube-proxy-key.pem                                                                     100% 1679     1.6KB/s   00:00
Warning: Permanently added 'compute.1617219287039593734' (ECDSA) to the list of known hosts.
ca.pem                                                                                 100% 1367     1.3KB/s   00:00
kube-proxy.pem                                                                         100% 1428     1.4KB/s   00:00
kube-proxy-key.pem                                                                     100% 1679     1.6KB/s   00:00