### PR TITLE
Enable kubectl portfw on workers, fixes #78

### DIFF
--- a/docs/01-infrastructure-gcp.md
+++ b/docs/01-infrastructure-gcp.md
@@ -147,6 +147,8 @@ gcloud compute instances create controller2 \
 
 #### Kubernetes Workers
 
+Include socat depedency on worker VMs to enable kubelet's portfw functionality.
+
 ```
 gcloud compute instances create worker0 \
  --boot-disk-size 200GB \
@@ -155,7 +157,11 @@ gcloud compute instances create worker0 \
  --image-project ubuntu-os-cloud \
  --machine-type n1-standard-1 \
  --private-network-ip 10.240.0.20 \
- --subnet kubernetes
+ --subnet kubernetes \
+ --metadata startup-script='#! /bin/bash
+apt-get update
+apt-get install -y socat
+EOF'
 ```
 
 ```
@@ -166,7 +172,11 @@ gcloud compute instances create worker1 \
  --image-project ubuntu-os-cloud \
  --machine-type n1-standard-1 \
  --private-network-ip 10.240.0.21 \
- --subnet kubernetes
+ --subnet kubernetes \
+ --metadata startup-script='#! /bin/bash
+apt-get update
+apt-get install -y socat
+EOF'
 ```
 
 ```
@@ -177,5 +187,9 @@ gcloud compute instances create worker2 \
  --image-project ubuntu-os-cloud \
  --machine-type n1-standard-1 \
  --private-network-ip 10.240.0.22 \
- --subnet kubernetes
+ --subnet kubernetes \
+ --metadata startup-script='#! /bin/bash
+apt-get update
+apt-get install -y socat
+EOF'
 ```


### PR DESCRIPTION
Based on upstream reviews of kubelet dependencies it does not sound like socat requirement for `kubectl port-forward` will go away anytime soon. Non-hard-way vendors package this with the kubelet. 