### PR TITLE
Update 05-kubernetes-controller.md

### DIFF
--- a/docs/05-kubernetes-controller.md
+++ b/docs/05-kubernetes-controller.md
@@ -56,19 +56,19 @@ sudo mv ca.pem ca-key.pem kubernetes-key.pem kubernetes.pem /var/lib/kubernetes/
 Download the official Kubernetes release binaries:
 
 ```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/linux/amd64/kube-apiserver
+wget https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kube-apiserver
 ```
 
 ```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/linux/amd64/kube-controller-manager
+wget https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kube-controller-manager
 ```
 
 ```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/linux/amd64/kube-scheduler
+wget https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kube-scheduler
 ```
 
 ```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/linux/amd64/kubectl
+wget https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl
 ```
 
 Install the Kubernetes binaries:


### PR DESCRIPTION
there is a bug in Kubernetes 1.6.1 that causes an error when validating the kubernetes environment and etcd.  (https://github.com/kubernetes/kubernetes/pull/39716)   I found that using the 1.7.0 version I did not get this error.  Affects the README, this file and the client configuration (moving to 1.7.0 to match)