### PR TITLE
fix KUBERNETES_PUBLIC_ADDRESS value

### DIFF
--- a/docs/05-kubernetes-controller.md
+++ b/docs/05-kubernetes-controller.md
@@ -298,7 +298,7 @@ gcloud compute target-pools add-instances kubernetes-target-pool \
 ```
 KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
   --region us-central1 \
-  --format 'value(address)')
+  --format 'value(name)')
 ```
 
 ```


### PR DESCRIPTION
Instead of 'value(address)' 'value(name)' should be used to make the following forwarding-rules creation command to work. With 'value(address)' it returns an error: "ERROR: (gcloud.compute.forwarding-rules.create) Could not fetch resource: - The resource 'projects/some-random-project/regions/us-central1/addresses/w.x.y.z' was not found"