### PR TITLE
Updating kubelet kube-proxy and kubectl to 1.7.2

### DIFF
--- a/docs/06-kubernetes-worker.md
+++ b/docs/06-kubernetes-worker.md
@@ -137,15 +137,15 @@ sudo tar -xvf cni-amd64-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz -C /opt/
 Download and install the Kubernetes worker binaries:
 
 ```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/linux/amd64/kubectl
+wget https://storage.googleapis.com/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl
 ```
 
 ```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/linux/amd64/kube-proxy
+wget https://storage.googleapis.com/kubernetes-release/release/v1.7.2/bin/linux/amd64/kube-proxy
 ```
 
 ```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/linux/amd64/kubelet
+wget https://storage.googleapis.com/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubelet
 ```
 
 ```


### PR DESCRIPTION
Existing steps were referring to 1.6.1, since the control plane components are already 1.7.2, it would be better to move worker components to 1.7.2 as well.