### PR TITLE
Update var name to be consistent with other lab steps.

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -235,7 +235,7 @@ gcloud compute forwarding-rules create kubernetes-forwarding-rule \
 Retrieve the `kubernetes-the-hard-way` static IP address:
 
 ```
-KUBERNETES_PUBLIC_IP_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
+KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
   --region $(gcloud config get-value compute/region) \
   --format 'value(address)')
 ```
@@ -243,7 +243,7 @@ KUBERNETES_PUBLIC_IP_ADDRESS=$(gcloud compute addresses describe kubernetes-the-
 Make a HTTP request for the Kubernetes version info:
 
 ```
-curl --cacert ca.pem https://${KUBERNETES_PUBLIC_IP_ADDRESS}:6443/version
+curl --cacert ca.pem https://${KUBERNETES_PUBLIC_ADDRESS}:6443/version
 ```
 
 > output


### PR DESCRIPTION
The var name should be consistent across all steps to allow the user to utilize the same value when completing the lab in a single run without having to re-enter the command.  The var is **KUBERNETES_PUBLIC_ADDRESS** on steps 4, 5, and 10 and **KUBERNETES_PUBLIC_IP_ADDRESS** on step 8 utilizing the same command and return value to gcloud compute addresses endpoint.