### PR TITLE
Changes necessary to run KTHW on RHEL

### DIFF
--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -12,9 +12,9 @@ Download and install `cfssl` and `cfssljson` from the [cfssl repository](https:/
 ### OS X
 
 ```
-wget -q --show-progress --https-only --timestamping \
-  https://pkg.cfssl.org/R1.2/cfssl_darwin-amd64 \
-  https://pkg.cfssl.org/R1.2/cfssljson_darwin-amd64
+curl \
+  -O https://pkg.cfssl.org/R1.2/cfssl_darwin-amd64 \
+  -O https://pkg.cfssl.org/R1.2/cfssljson_darwin-amd64
 ```
 
 ```
@@ -32,9 +32,9 @@ sudo mv cfssljson_darwin-amd64 /usr/local/bin/cfssljson
 ### Linux
 
 ```
-wget -q --show-progress --https-only --timestamping \
-  https://pkg.cfssl.org/R1.2/cfssl_linux-amd64 \
-  https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
+curl \
+  -O https://pkg.cfssl.org/R1.2/cfssl_linux-amd64 \
+  -O https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
 ```
 
 ```
@@ -74,7 +74,7 @@ The `kubectl` command line utility is used to interact with the Kubernetes API S
 ### OS X
 
 ```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/darwin/amd64/kubectl
+curl -O https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/darwin/amd64/kubectl
 ```
 
 ```
@@ -88,7 +88,7 @@ sudo mv kubectl /usr/local/bin/
 ### Linux
 
 ```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl
+curl -O https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl
 ```
 
 ```

--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -104,6 +104,8 @@ kubernetes-the-hard-way  us-west1  XX.XXX.XXX.XX  RESERVED
 
 The compute instances in this lab will be provisioned using [Ubuntu Server](https://www.ubuntu.com/server) 16.04, which has good support for the [CRI-O container runtime](https://github.com/kubernetes-incubator/cri-o). Each compute instance will be provisioned with a fixed private IP address to simplify the Kubernetes bootstrapping process.
 
+Kubernetes the Hard Way also works well on Red Hat Enterprise Linux 7.4 (modulo a few tweaks to prerequisite package names).
+
 ### Kubernetes Controllers
 
 Create three compute instances which will host the Kubernetes control plane:
@@ -148,6 +150,7 @@ for i in 0 1 2; do
     --tags kubernetes-the-hard-way,worker
  done
 ```
+To use RHEL7.4, change --image-family to ```rhel-7``` and --image-project to ```rhel-cloud```.
 
 ### Verification
 

--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -17,8 +17,8 @@ gcloud compute ssh controller-0
 Download the official etcd release binaries from the [coreos/etcd](https://github.com/coreos/etcd) GitHub project:
 
 ```
-wget -q --show-progress --https-only --timestamping \
-  "https://github.com/coreos/etcd/releases/download/v3.2.6/etcd-v3.2.6-linux-amd64.tar.gz"
+curl \
+  -O "https://github.com/coreos/etcd/releases/download/v3.2.6/etcd-v3.2.6-linux-amd64.tar.gz"
 ```
 
 Extract and install the `etcd` server and the `etcdctl` command line utility:

--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -18,7 +18,7 @@ Download the official etcd release binaries from the [coreos/etcd](https://githu
 
 ```
 curl \
-  -O "https://github.com/coreos/etcd/releases/download/v3.2.6/etcd-v3.2.6-linux-amd64.tar.gz"
+  -L -O "https://github.com/coreos/etcd/releases/download/v3.2.6/etcd-v3.2.6-linux-amd64.tar.gz"
 ```
 
 Extract and install the `etcd` server and the `etcdctl` command line utility:

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -17,11 +17,11 @@ gcloud compute ssh controller-0
 Download the official Kubernetes release binaries:
 
 ```
-wget -q --show-progress --https-only --timestamping \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kube-apiserver" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kube-controller-manager" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kube-scheduler" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl"
+curl \
+  -O "https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kube-apiserver" \
+  -O "https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kube-controller-manager" \
+  -O "https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kube-scheduler" \
+  -O "https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl"
 ```
 
 Install the Kubernetes binaries:

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -37,6 +37,11 @@ For RHEL, run:
 sudo yum install -y socat device-mapper-libs ostree
 ```
 
+Also for RHEL, the specific library version used to build crio has not yet been released yet.  For now, symlink like so:
+```
+sudo ln -s /usr/lib64/libdevmapper.so.1.02 /usr/lib64/libdevmapper.so.1.02.1
+```
+
 ### Download and Install Worker Binaries
 
 ```

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -16,6 +16,8 @@ gcloud compute ssh worker-0
 
 Add the `alexlarsson/flatpak` [PPA](https://launchpad.net/ubuntu/+ppas) which hosts the `libostree` package:
 
+`libostree` is provided by the `ostree` RPM on RHEL7.
+
 ```
 sudo add-apt-repository -y ppa:alexlarsson/flatpak
 ```
@@ -30,16 +32,21 @@ Install the OS dependencies required by the cri-o container runtime:
 sudo apt-get install -y socat libgpgme11 libostree-1-1
 ```
 
+For RHEL, run:
+```
+sudo yum install -y socat device-mapper-libs ostree
+```
+
 ### Download and Install Worker Binaries
 
 ```
-wget -q --show-progress --https-only --timestamping \
-  https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz \
-  https://github.com/opencontainers/runc/releases/download/v1.0.0-rc4/runc.amd64 \
-  https://storage.googleapis.com/kubernetes-the-hard-way/crio-amd64-v1.0.0-beta.0.tar.gz \
-  https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl \
-  https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kube-proxy \
-  https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubelet
+curl \
+  -O https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz \
+  -O https://github.com/opencontainers/runc/releases/download/v1.0.0-rc4/runc.amd64 \
+  -O https://storage.googleapis.com/kubernetes-the-hard-way/crio-amd64-v1.0.0-beta.0.tar.gz \
+  -O https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl \
+  -O https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kube-proxy \
+  -O https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubelet
 ```
 
 Create the installation directories:

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -37,7 +37,7 @@ For RHEL, run:
 sudo yum install -y socat device-mapper-libs ostree
 ```
 
-Also for RHEL, the specific library version used to build crio has not yet been released yet.  For now, symlink like so:
+Also for RHEL, the specific library version used to build crio has not yet been released.  For now, symlink like so:
 ```
 sudo ln -s /usr/lib64/libdevmapper.so.1.02 /usr/lib64/libdevmapper.so.1.02.1
 ```

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -46,8 +46,8 @@ sudo ln -s /usr/lib64/libdevmapper.so.1.02 /usr/lib64/libdevmapper.so.1.02.1
 
 ```
 curl \
-  -O https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz \
-  -O https://github.com/opencontainers/runc/releases/download/v1.0.0-rc4/runc.amd64 \
+  -L -O https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz \
+  -L -O https://github.com/opencontainers/runc/releases/download/v1.0.0-rc4/runc.amd64 \
   -O https://storage.googleapis.com/kubernetes-the-hard-way/crio-amd64-v1.0.0-beta.0.tar.gz \
   -O https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl \
   -O https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kube-proxy \


### PR DESCRIPTION
Hi, I hope this is OK with you:

- Changed from wget to curl, due to unsupported (on RHEL7) wget options used.
  - This makes it so the same download command works on both Ubuntu and RHEL.
- Add yum command that satisfies library dependencies for crio.
  - ```/usr/lib64/libostree-1.so.1``` is provided by the ostree package on RHEL)
- Install socat for the ```kubectl port-forward``` step (not installed by default on RHEL)
- Add a symlink command...this is a bit squirrely, maybe @mrunalp can compile a new version of crio that doesn't require this specific (unreleased) bleeding edge ```/usr/lib64/libdevmapper.so.1.02.1```?