### PR TITLE
Instructions for having a default configuration.

### DIFF
--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -24,7 +24,13 @@ gcloud version
 
 This tutorial assumes a default compute region and zone have been configured.
 
-Set a default compute region:
+If you are using the `gcloud` command-line tool for the first time `init` is the easiest way to do this:
+
+```
+gcloud init
+```
+
+Otherwise set a default compute region:
 
 ```
 gcloud config set compute/region us-west1


### PR DESCRIPTION
I ran into the same problem as described in issue https://github.com/kelseyhightower/kubernetes-the-hard-way/issues/219 and thought it might make sense to mention `gcloud init` in the setup docs.

Thanks for creating this tutorial. I'm very excited to work through it. 