### PR TITLE
Fix typo

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -269,7 +269,7 @@ gcloud compute target-pools add-instances kubernetes-target-pool \
 ```
 KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
   --region $(gcloud config get-value compute/region) \
-  --format 'value(name)')
+  --format 'value(address)')
 ```
 
 ```


### PR DESCRIPTION
I validated each command and the result of the `KUBERNETES_PUBLIC_ADDRESS` looked wrong.

I'd not remove the second variable export for `KUBERNETES_PUBLIC_ADDRESS`, if something is debugging something he might accidentally try the validation in a new shell and forget about the export.