### PR TITLE
Add --etcd-quorum-read to apiserver arguments

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -76,6 +76,7 @@ ExecStart=/usr/local/bin/kube-apiserver \\
   --etcd-cafile=/var/lib/kubernetes/ca.pem \\
   --etcd-certfile=/var/lib/kubernetes/kubernetes.pem \\
   --etcd-keyfile=/var/lib/kubernetes/kubernetes-key.pem \\
+  --etcd-quorum-read \\
   --etcd-servers=https://10.240.0.10:2379,https://10.240.0.11:2379,https://10.240.0.12:2379 \\
   --event-ttl=1h \\
   --experimental-encryption-provider-config=/var/lib/kubernetes/encryption-config.yaml \\


### PR DESCRIPTION
I've been told that if you're going to run a HA apiserver configuration you need `--etcd-quorum-read` otherwise the apiservers will end up reading inconsistent data from etcd. Assuming that's true I think it would be good to include it here.