### PR TITLE
Deprecated gcloud parameter + Typo

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -17,7 +17,7 @@ In this section a dedicated [Virtual Private Cloud](https://cloud.google.com/com
 Create the `kubernetes-the-hard-way` custom VPC network:
 
 ```
-gcloud compute networks create kubernetes-the-hard-way --mode custom
+gcloud compute networks create kubernetes-the-hard-way --subnet-mode custom
 ```
 
 A [subnet](https://cloud.google.com/compute/docs/vpc/#vpc_networks_and_subnets) must be provisioned with an IP address range large enough to assign a private IP address to each node in the Kubernetes cluster.

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -269,7 +269,7 @@ gcloud compute target-pools add-instances kubernetes-target-pool \
 ```
 KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
   --region $(gcloud config get-value compute/region) \
-  --format 'value(name)')
+  --format 'value(address)')
 ```
 
 ```


### PR DESCRIPTION
gcloud has deprecated the --mode parameter and now the advise is to use --subnet-mode instead.

As per the gcloud documentation (`gcloud compute networks create --help`):
```
-mode=NETWORK_TYPE
    (DEPRECATED) The network type.

    mode is deprecated. Please use subnet-mode instead. NETWORK_TYPE must
    be one of:

  auto
    Subnets are created automatically. This is the recommended selection.
  custom
    Create subnets manually.
  legacy
    Create an old style network that has a range and cannot have subnets.
    This is not recommended for new networks.
```