### PR TITLE
remove --require-kubeconfig flag

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -148,7 +148,6 @@ ExecStart=/usr/local/bin/kubelet \\
   --network-plugin=cni \\
   --pod-cidr=${POD_CIDR} \\
   --register-node=true \\
-  --require-kubeconfig \\
   --runtime-request-timeout=15m \\
   --tls-cert-file=/var/lib/kubelet/${HOSTNAME}.pem \\
   --tls-private-key-file=/var/lib/kubelet/${HOSTNAME}-key.pem \\


### PR DESCRIPTION
In v1.8.0 later, the flag `--require-kubeconfig` has been deprecated, no longer need to use `--require-kubeconfig`.