### PR TITLE
Amend output of the get pods command

### DIFF
--- a/docs/12-dns-addon.md
+++ b/docs/12-dns-addon.md
@@ -30,7 +30,6 @@ kubectl get pods -l k8s-app=kube-dns -n kube-system
 ```
 NAME                        READY     STATUS    RESTARTS   AGE
 kube-dns-3097350089-gq015   3/3       Running   0          20s
-kube-dns-3097350089-q64qc   3/3       Running   0          20s
 ```
 
 ## Verification


### PR DESCRIPTION
Still somewhat of a k8s n00b, so sorry if I'm out of line here, but I'd like to propose a small amendment to the output of the get pods command confirming the deployment of the kube-dns add-on. 

This seems like a deployment creating a single replicaset by default, the output should then list a single RS.

From the deployment's YAML file:

```
spec:
  # replicas: not specified here:
  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
  # 2. Default is 1.
  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
```

Output of a describe of the resulting deployment:

```
kubectl describe deployment kube-dns -n kube-system | grep ReplicaSet
OldReplicaSets:  <none>
NewReplicaSet:   kube-dns-6c857864fb (1/1 replicas created)
```