### PR TITLE
Argument syntax for Filter deprecated.

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -57,7 +57,7 @@ gcloud compute firewall-rules create kubernetes-the-hard-way-allow-external \
 List the firewall rules in the `kubernetes-the-hard-way` VPC network:
 
 ```
-gcloud compute firewall-rules list --filter "network: kubernetes-the-hard-way"
+gcloud compute firewall-rules list --filter="network:kubernetes-the-hard-way"
 ```
 
 > output


### PR DESCRIPTION
Operator evaluation is changing for consistency across Google APIs.