### PR TITLE
Fixed KUBERNETES_PUBLIC_ADDRESS gcloud output

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -269,7 +269,7 @@ gcloud compute target-pools add-instances kubernetes-target-pool \
 ```
 KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
   --region $(gcloud config get-value compute/region) \
-  --format 'value(name)')
+  --format 'value(address)')
 ```
 
 ```


### PR DESCRIPTION
in module 8 during load balancer setup, gcloud format incorrectly specified --format 'value(name)' instead of --format 'value(address)'