### PR TITLE
Install cfssl with brew instead of downloading it

### DIFF
--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -12,16 +12,7 @@ Download and install `cfssl` and `cfssljson` from the [cfssl repository](https:/
 ### OS X
 
 ```
-curl -o cfssl https://pkg.cfssl.org/R1.2/cfssl_darwin-amd64
-curl -o cfssljson https://pkg.cfssl.org/R1.2/cfssljson_darwin-amd64
-```
-
-```
-chmod +x cfssl cfssljson
-```
-
-```
-sudo mv cfssl cfssljson /usr/local/bin/
+brew install cfssl
 ```
 
 ### Linux


### PR DESCRIPTION
When trying the current suggestion for installing cfssl on osx high sierra I got errors that lead me to this issue - https://github.com/cloudflare/cfssl/issues/813, which taught me cfssl has a brew package. I feel it's more concise to use brew for this operation + it let's users avoid the error I got. WDYT?