### PR TITLE
Add alternative installation for kubectl and cfssl

### DIFF
--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -24,6 +24,12 @@ chmod +x cfssl cfssljson
 sudo mv cfssl cfssljson /usr/local/bin/
 ```
 
+Or install with Homebrew:
+
+```
+brew install cfssl
+```
+
 ### Linux
 
 ```
@@ -78,6 +84,12 @@ chmod +x kubectl
 
 ```
 sudo mv kubectl /usr/local/bin/
+```
+
+Or install via Homebrew:
+
+```
+brew install kubectl
 ```
 
 ### Linux


### PR DESCRIPTION
Added alternative installation method for `kubectl` and `cfssl` for Mac, via Homebrew.