### PR TITLE
Fix a reference to the public name where an address is expected

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -269,7 +269,7 @@ gcloud compute target-pools add-instances kubernetes-target-pool \
 ```
 KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
   --region $(gcloud config get-value compute/region) \
-  --format 'value(name)')
+  --format 'value(address)')
 ```
 
 ```


### PR DESCRIPTION
I came across this issue confusing someone in the kubernetes slack channel -- looks like we're pulling the name attribute of the address instead of the IP address itself.