### PR TITLE
Update 02-client-tools.md

### DIFF
--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -11,18 +11,7 @@ Download and install `cfssl` and `cfssljson` from the [cfssl repository](https:/
 
 ### OS X
 
-```
-curl -o cfssl https://pkg.cfssl.org/R1.2/cfssl_darwin-amd64
-curl -o cfssljson https://pkg.cfssl.org/R1.2/cfssljson_darwin-amd64
-```
-
-```
-chmod +x cfssl cfssljson
-```
-
-```
-sudo mv cfssl cfssljson /usr/local/bin/
-```
+`brew install cfssl`
 
 ### Linux
 


### PR DESCRIPTION
High Sierra 10.13.3

installing manually with curl and trying to use `cfssl`/`cfssljson` results in `Fatal Error: MSpanList_Insert`