### PR TITLE
Update 08-bootstrapping-kubernetes-controllers.md

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -293,7 +293,7 @@ KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-har
 Make a HTTP request for the Kubernetes version info:
 
 ```
-curl --cacert ca.pem https://${KUBERNETES_PUBLIC_ADDRESS}:6443/version
+curl --cacert ca.pem https://$KUBERNETES_PUBLIC_ADDRESS:6443/version
 ```
 
 > output


### PR DESCRIPTION
On OSX 10.13.4 (zsh), the existing command does not work when environment variable is wrapped in curly brackets.

I have deleted the curly brackets from the command. Works on my machine..