### PR TITLE
Update 13-smoke-test.md

### DIFF
--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -187,7 +187,7 @@ EXTERNAL_IP=$(gcloud compute instances describe worker-0 \
 Make an HTTP request using the external IP address and the `nginx` node port:
 
 ```
-curl -I http://${EXTERNAL_IP}:${NODE_PORT}
+curl -I http://$EXTERNAL_IP:$NODE_PORT
 ```
 
 > output


### PR DESCRIPTION
Changed:

```
curl -I http://${EXTERNAL_IP}:${NODE_PORT}
```

To:

```
curl -I http://$EXTERNAL_IP:$NODE_PORT
```

The original command does not work on OSX.