### PR TITLE
Add Results after generating kube-proxy kubeconfig

### DIFF
--- a/docs/05-kubernetes-configuration-files.md
+++ b/docs/05-kubernetes-configuration-files.md
@@ -88,6 +88,12 @@ kubectl config set-context default \
 kubectl config use-context default --kubeconfig=kube-proxy.kubeconfig
 ```
 
+Results:
+
+```
+kube-proxy.kubeconfig
+```
+
 ## Distribute the Kubernetes Configuration Files
 
 Copy the appropriate `kubelet` and `kube-proxy` kubeconfig files to each worker instance:


### PR DESCRIPTION
Adding Results section after generating kube-proxy kubeconfig, similar to when we create kubeconfig for worker nodes.