### PR TITLE
`sudo apt-get update` before installing socat

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -15,6 +15,7 @@ gcloud compute ssh worker-0
 Install the OS dependencies:
 
 ```
+sudo apt-get update
 sudo apt-get -y install socat
 ```
 


### PR DESCRIPTION
Without this I was getting:

```sh
@worker-0:~$ sudo apt-get -y install socat
Reading package lists... Done
Building dependency tree
Reading state information... Done
E: Unable to locate package socat
```