### PR TITLE
Create directory at /var/lib/kubernetes/ before moving config

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -114,7 +114,10 @@ EOF
 Move the `kube-controller-manager` kubeconfig into place:
 
 ```
-sudo mv kube-controller-manager.kubeconfig /var/lib/kubernetes/
+{
+  sudo mkdir -p /var/lib/kubernetes/
+  sudo mv kube-controller-manager.kubeconfig /var/lib/kubernetes/
+}
 ```
 
 Create the `kube-controller-manager.service` systemd unit file:


### PR DESCRIPTION
First of all thanks for the great tutorial!

When I did the tutorial, I noticed that the folder `/var/lib/kubernetes/` is missing when moving the kubernetes-controller config. I added the `mkdir` statement to the docs.

```
{
  + sudo mkdir -p /var/lib/kubernetes/
  sudo mv kube-controller-manager.kubeconfig /var/lib/kubernetes/
}
```

Cheers!