### PR TITLE
Make controller IP and Service IP named variables

### DIFF
--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -327,11 +327,13 @@ for i in 0 1 2; do
     --format 'value(networkInterfaces[0].networkIP)');
 done
 
+API_SERVER_SERVICE_IP=10.32.0.1
+
 cfssl gencert \
   -ca=ca.pem \
   -ca-key=ca-key.pem \
   -config=ca-config.json \
-  -hostname=10.32.0.1,${CONTROLLER_0},${CONTROLLER_1},${CONTROLLER_2},${KUBERNETES_PUBLIC_ADDRESS},127.0.0.1,kubernetes.default \
+  -hostname=${API_SERVER_SERVICE_IP},${CONTROLLER_0},${CONTROLLER_1},${CONTROLLER_2},${KUBERNETES_PUBLIC_ADDRESS},127.0.0.1,kubernetes.default \
   -profile=kubernetes \
   kubernetes-csr.json | cfssljson -bare kubernetes
 

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -322,11 +322,16 @@ cat > kubernetes-csr.json <<EOF
 }
 EOF
 
+for i in 0 1 2; do
+  declare CONTROLLER_${i}=$(gcloud compute instances describe controller-$i \
+    --format 'value(networkInterfaces[0].networkIP)');
+done
+
 cfssl gencert \
   -ca=ca.pem \
   -ca-key=ca-key.pem \
   -config=ca-config.json \
-  -hostname=10.32.0.1,10.240.0.10,10.240.0.11,10.240.0.12,${KUBERNETES_PUBLIC_ADDRESS},127.0.0.1,kubernetes.default \
+  -hostname=10.32.0.1,${CONTROLLER_0},${CONTROLLER_1},${CONTROLLER_2},${KUBERNETES_PUBLIC_ADDRESS},127.0.0.1,kubernetes.default \
   -profile=kubernetes \
   kubernetes-csr.json | cfssljson -bare kubernetes
 


### PR DESCRIPTION
I found it useful to have the controller IP addresses and API server service IP given in the API server certificate creation script documented as variables instead of just hardcoded for understanding why those IPs were chosen.  It was also handy for an occasion where the example subnet was not available for me to use for the lab, and I needed to use a different subnet for the controllers.
