### PR TITLE
Reintroduce AWS code with different presentation and some improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Kubernetes The Hard Way guides you through bootstrapping a highly available Kube
 
 ## Labs
 
-This tutorial assumes you have access to the [Google Cloud Platform](https://cloud.google.com). While GCP is used for basic infrastructure requirements the lessons learned in this tutorial can be applied to other platforms.
+This tutorial assumes you have access to the [Google Cloud Platform](https://cloud.google.com/), or [Amazon Web Services](https://aws.amazon.com/). While GCP/AWS is used for basic infrastructure requirements the lessons learned in this tutorial can be applied to other platforms.
 
 * [Prerequisites](docs/01-prerequisites.md)
 * [Installing the Client Tools](docs/02-client-tools.md)

--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -1,5 +1,10 @@
 # Prerequisites
 
+This tutorial uses Google Cloud Platform (`GCP`) to provision instrastructure required by the Kubernetes cluster, however code is also provided for users who prefer to use Amazon Web Services, in expandable sections marked `AWS`.
+
+<details open>
+<summary>GCP</summary>
+
 ## Google Cloud Platform
 
 This tutorial leverages the [Google Cloud Platform](https://cloud.google.com/) to streamline provisioning of the compute infrastructure required to bootstrap a Kubernetes cluster from the ground up. [Sign up](https://cloud.google.com/free/) for $300 in free credits.
@@ -43,6 +48,44 @@ gcloud config set compute/zone us-west1-c
 ```
 
 > Use the `gcloud compute zones list` command to view additional regions and zones.
+</details>
+
+<details>
+<summary>AWS</summary>
+
+## Amazon Web Services
+
+This tutorial leverages the [Amazon Web Services](https://aws.amazon.com/) to streamline provisioning of the compute infrastructure required to bootstrap a Kubernetes cluster from the ground up. [Sign up](https://portal.aws.amazon.com/billing/signup) for [12 months of free services](https://aws.amazon.com/free/).
+
+> The compute resources required for this tutorial exceed the Amazon Web Services free tier.
+
+## Amazon Web Services CLI
+
+### Install the Amazon Web Services CLI
+
+Follow the Amazon Web Services CLI [documentation](https://aws.amazon.com/cli/) to install and configure the `aws` command line utility.
+
+### Configure the kubernetes-the-hard-way profile
+
+Throughout this tutorial, an aws profile named `kubernetes-the-hard-way` will be used.
+
+Create the profile and set its default region (us-west-2 in this example):
+
+```
+aws configure set region us-west-2 \
+  --profile kubernetes-the-hard-way
+```
+
+Set the credentials for the profile to the same set as in the default profile:
+
+```
+aws configure set aws_access_key_id "$(aws configure get aws_access_key_id)" \
+  --profile kubernetes-the-hard-way
+
+aws configure set aws_secret_access_key "$(aws configure get aws_secret_access_key)" \
+  --profile kubernetes-the-hard-way
+```
+</details>
 
 ## Running Commands in Parallel with tmux
 

--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -12,15 +12,51 @@ The Kubernetes [networking model](https://kubernetes.io/docs/concepts/cluster-ad
 
 ### Virtual Private Cloud Network
 
+
 In this section a dedicated [Virtual Private Cloud](https://cloud.google.com/compute/docs/networks-and-firewalls#networks) (VPC) network will be setup to host the Kubernetes cluster.
 
 Create the `kubernetes-the-hard-way` custom VPC network:
+
+<details open>
+<summary>GCP</summary>
 
 ```
 gcloud compute networks create kubernetes-the-hard-way --subnet-mode custom
 ```
 
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+VPC_ID="$(aws ec2 create-vpc \
+  --cidr-block 10.240.0.0/24 \
+  --profile kubernetes-the-hard-way \
+  --query Vpc.VpcId \
+  --output text)"
+```
+```
+for opt in support hostnames; do
+  aws ec2 modify-vpc-attribute \
+    --vpc-id "$VPC_ID" \
+    --enable-dns-"$opt" '{"Value": true}' \
+    --profile kubernetes-the-hard-way
+done
+
+aws ec2 create-tags \
+  --resources "$VPC_ID" \
+  --tags Key=kubernetes.io/cluster/kubernetes-the-hard-way,Value=shared \
+  --profile kubernetes-the-hard-way
+```
+
+</details>
+<p></p>
+
 A [subnet](https://cloud.google.com/compute/docs/vpc/#vpc_networks_and_subnets) must be provisioned with an IP address range large enough to assign a private IP address to each node in the Kubernetes cluster.
+
+<details open>
+<summary>GCP</summary>
 
 Create the `kubernetes` subnet in the `kubernetes-the-hard-way` VPC network:
 
@@ -30,11 +66,91 @@ gcloud compute networks subnets create kubernetes \
   --range 10.240.0.0/24
 ```
 
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+DHCP_OPTIONS_ID="$(aws ec2 create-dhcp-options \
+  --dhcp-configuration \
+    "Key=domain-name,Values=$(aws configure get region --profile kubernetes-the-hard-way).compute.internal" \
+    "Key=domain-name-servers,Values=AmazonProvidedDNS" \
+  --profile kubernetes-the-hard-way \
+  --query DhcpOptions.DhcpOptionsId \
+  --output text)"
+
+aws ec2 create-tags \
+  --resources "$DHCP_OPTIONS_ID" \
+  --tags Key=kubernetes.io/cluster/kubernetes-the-hard-way,Value=shared \
+  --profile kubernetes-the-hard-way
+
+aws ec2 associate-dhcp-options \
+  --dhcp-options-id "$DHCP_OPTIONS_ID" \
+  --vpc-id "$VPC_ID" \
+  --profile kubernetes-the-hard-way
+
+SUBNET_ID="$(aws ec2 create-subnet \
+  --vpc-id "$VPC_ID" \
+  --cidr-block 10.240.0.0/24 \
+  --profile kubernetes-the-hard-way \
+  --query Subnet.SubnetId \
+  --output text)"
+
+aws ec2 create-tags \
+  --resources "$SUBNET_ID" \
+  --tags Key=kubernetes.io/cluster/kubernetes-the-hard-way,Value=shared \
+  --profile kubernetes-the-hard-way
+
+INTERNET_GATEWAY_ID="$(aws ec2 create-internet-gateway \
+  --profile kubernetes-the-hard-way \
+  --query InternetGateway.InternetGatewayId \
+  --output text)"
+
+aws ec2 create-tags \
+  --resources "$INTERNET_GATEWAY_ID" \
+  --tags Key=kubernetes.io/cluster/kubernetes-the-hard-way,Value=shared \
+  --profile kubernetes-the-hard-way
+
+aws ec2 attach-internet-gateway \
+  --internet-gateway-id "$INTERNET_GATEWAY_ID" \
+  --vpc-id "$VPC_ID" \
+  --profile kubernetes-the-hard-way
+
+ROUTE_TABLE_ID="$(aws ec2 create-route-table \
+  --vpc-id "$VPC_ID" \
+  --profile kubernetes-the-hard-way \
+  --query RouteTable.RouteTableId \
+  --output text)"
+
+aws ec2 create-tags \
+  --resources "$ROUTE_TABLE_ID" \
+  --tags Key=kubernetes.io/cluster/kubernetes-the-hard-way,Value=shared \
+  --profile kubernetes-the-hard-way
+
+aws ec2 associate-route-table \
+  --route-table-id "$ROUTE_TABLE_ID" \
+  --subnet-id "$SUBNET_ID" \
+  --profile kubernetes-the-hard-way
+
+aws ec2 create-route \
+  --route-table-id "$ROUTE_TABLE_ID" \
+  --destination-cidr-block 0.0.0.0/0 \
+  --gateway-id "$INTERNET_GATEWAY_ID" \
+  --profile kubernetes-the-hard-way
+```
+
+</details>
+<p></p>
+
 > The `10.240.0.0/24` IP address range can host up to 254 compute instances.
 
 ### Firewall Rules
 
 Create a firewall rule that allows internal communication across all protocols:
+
+<details open>
+<summary>GCP</summary>
 
 ```
 gcloud compute firewall-rules create kubernetes-the-hard-way-allow-internal \
@@ -43,7 +159,47 @@ gcloud compute firewall-rules create kubernetes-the-hard-way-allow-internal \
   --source-ranges 10.240.0.0/24,10.200.0.0/16
 ```
 
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+SECURITY_GROUP_ID="$(aws ec2 create-security-group \
+  --group-name kubernetes-the-hard-way \
+  --description kubernetes-the-hard-way \
+  --vpc-id "$VPC_ID" \
+  --profile kubernetes-the-hard-way \
+  --query GroupId \
+  --output text)"
+
+aws ec2 create-tags \
+  --resources "$SECURITY_GROUP_ID" \
+  --tags Key=kubernetes.io/cluster/kubernetes-the-hard-way,Value=shared \
+  --profile kubernetes-the-hard-way
+```
+```
+allow() {
+  aws ec2 authorize-security-group-ingress \
+    --profile kubernetes-the-hard-way \
+    --group-id "$SECURITY_GROUP_ID" \
+    "$@"
+}
+
+allow --protocol all --source-group "$SECURITY_GROUP_ID"
+
+for network in 10.200.0.0/16 10.240.0.0/24; do
+  allow --protocol all --cidr "$network"
+done
+```
+
+</details>
+<p></p>
+
 Create a firewall rule that allows external SSH, ICMP, and HTTPS:
+
+<details open>
+<summary>GCP</summary>
 
 ```
 gcloud compute firewall-rules create kubernetes-the-hard-way-allow-external \
@@ -54,7 +210,28 @@ gcloud compute firewall-rules create kubernetes-the-hard-way-allow-external \
 
 > An [external load balancer](https://cloud.google.com/compute/docs/load-balancing/network/) will be used to expose the Kubernetes API Servers to remote clients.
 
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+allow --protocol icmp --port 3-4 --cidr 0.0.0.0/0
+
+for port in 22 6443; do
+  allow --protocol tcp --port "$port" --cidr 0.0.0.0/0
+done
+```
+
+> An [external load balancer](https://aws.amazon.com/elasticloadbalancing/) will be used to expose the Kubernetes API Servers to remote clients.
+
+</details>
+<p></p>
+
 List the firewall rules in the `kubernetes-the-hard-way` VPC network:
+
+<details open>
+<summary>GCP</summary>
 
 ```
 gcloud compute firewall-rules list --filter="network:kubernetes-the-hard-way"
@@ -68,7 +245,76 @@ kubernetes-the-hard-way-allow-external  kubernetes-the-hard-way  INGRESS    1000
 kubernetes-the-hard-way-allow-internal  kubernetes-the-hard-way  INGRESS    1000      tcp,udp,icmp
 ```
 
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+aws ec2 describe-security-groups \
+  --filters Name=group-id,Values="$SECURITY_GROUP_ID" \
+  --profile kubernetes-the-hard-way \
+  --query 'SecurityGroups[0].IpPermissions[].{GroupIds:UserIdGroupPairs[].GroupId,FromPort:FromPort,ToPort:ToPort,IpProtocol:IpProtocol,CidrIps:IpRanges[].CidrIp}' \
+  --output table|\
+  sed 's/| *DescribeSecurityGroups *|//g'|\
+  tail -n +3
+```
+
+> output
+
+```
++----------+--------------+----------+
+| FromPort | IpProtocol   | ToPort   |
++----------+--------------+----------+
+|  None    |  -1          |  None    |
++----------+--------------+----------+
+||              CidrIps             ||
+|+----------------------------------+|
+||  10.200.0.0/16                   ||
+||  10.240.0.0/24                   ||
+|+----------------------------------+|
+||             GroupIds             ||
+|+----------------------------------+|
+||  sg-b33811c3                     ||
+|+----------------------------------+|
+
++----------+--------------+----------+
+| FromPort | IpProtocol   | ToPort   |
++----------+--------------+----------+
+|  22      |  tcp         |  22      |
++----------+--------------+----------+
+||              CidrIps             ||
+|+----------------------------------+|
+||  0.0.0.0/0                       ||
+|+----------------------------------+|
+
++----------+--------------+----------+
+| FromPort | IpProtocol   | ToPort   |
++----------+--------------+----------+
+|  6443    |  tcp         |  6443    |
++----------+--------------+----------+
+||              CidrIps             ||
+|+----------------------------------+|
+||  0.0.0.0/0                       ||
+|+----------------------------------+|
+
++----------+--------------+----------+
+| FromPort | IpProtocol   | ToPort   |
++----------+--------------+----------+
+|  3       |  icmp        |  4       |
++----------+--------------+----------+
+||              CidrIps             ||
+|+----------------------------------+|
+||  0.0.0.0/0                       ||
+|+----------------------------------+|
+```
+
+</details>
+
 ### Kubernetes Public IP Address
+
+<details open>
+<summary>GCP</summary>
 
 Allocate a static IP address that will be attached to the external load balancer fronting the Kubernetes API Servers:
 
@@ -90,13 +336,119 @@ NAME                     REGION    ADDRESS        STATUS
 kubernetes-the-hard-way  us-west1  XX.XXX.XXX.XX  RESERVED
 ```
 
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+aws elb create-load-balancer \
+  --load-balancer-name kubernetes-the-hard-way \
+  --listeners Protocol=TCP,LoadBalancerPort=6443,InstanceProtocol=TCP,InstancePort=6443 \
+  --subnets "$SUBNET_ID" \
+  --security-groups "$SECURITY_GROUP_ID" \
+  --profile kubernetes-the-hard-way
+```
+
+> output
+
+```
+{
+    "DNSName": "kubernetes-the-hard-way-382204365.us-west-2.elb.amazonaws.com"
+}
+```
+
+</details>
+
 ## Compute Instances
 
 The compute instances in this lab will be provisioned using [Ubuntu Server](https://www.ubuntu.com/server) 18.04, which has good support for the [containerd container runtime](https://github.com/containerd/containerd). Each compute instance will be provisioned with a fixed private IP address to simplify the Kubernetes bootstrapping process.
 
+<details>
+<summary>AWS</summary>
+
+### Create Instance IAM Policies
+
+```
+cat >kubernetes-iam-role.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Service": "ec2.amazonaws.com"
+    },
+    "Action": "sts:AssumeRole"
+  }]
+}
+EOF
+
+aws iam create-role \
+  --role-name kubernetes-the-hard-way \
+  --assume-role-policy-document file://kubernetes-iam-role.json \
+  --profile kubernetes-the-hard-way
+
+cat >kubernetes-iam-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Resource": "*",
+    "Action": [
+      "ec2:*",
+      "elasticloadbalancing:*",
+      "route53:*",
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+      "ecr:BatchGetImage"
+    ]
+  }]
+}
+EOF
+
+aws iam put-role-policy \
+  --role-name kubernetes-the-hard-way \
+  --policy-name kubernetes-the-hard-way \
+  --policy-document file://kubernetes-iam-policy.json \
+  --profile kubernetes-the-hard-way
+
+aws iam create-instance-profile \
+  --instance-profile-name kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way
+
+aws iam add-role-to-instance-profile \
+  --instance-profile-name kubernetes-the-hard-way \
+  --role-name kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way
+```
+
+### Chosing an Image
+
+```
+IMAGE_ID="$(aws ec2 describe-images \
+  --owners 099720109477 \
+  --region "$(aws configure get region --profile kubernetes-the-hard-way)" \
+  --filters \
+    Name=root-device-type,Values=ebs \
+    Name=architecture,Values=x86_64 \
+    'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*' \
+  --profile kubernetes-the-hard-way \
+  --query 'sort_by(Images,&Name)[-1].ImageId' \
+  --output text)"
+```
+
+</details>
+
 ### Kubernetes Controllers
 
 Create three compute instances which will host the Kubernetes control plane:
+
+<details open>
+<summary>GCP</summary>
 
 ```
 for i in 0 1 2; do
@@ -114,6 +466,47 @@ for i in 0 1 2; do
 done
 ```
 
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+# For ssh access to ec2 machines.
+aws ec2 create-key-pair \
+  --key-name kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way \
+  --query KeyMaterial \
+  --output text >~/.ssh/kubernetes-the-hard-way
+
+chmod 600 ~/.ssh/kubernetes-the-hard-way
+
+for i in 0 1 2; do
+  instance_id="$(aws ec2 run-instances \
+    --associate-public-ip-address \
+    --iam-instance-profile Name=kubernetes-the-hard-way \
+    --image-id "$IMAGE_ID" \
+    --count 1 \
+    --key-name kubernetes-the-hard-way \
+    --security-group-ids "$SECURITY_GROUP_ID" \
+    --instance-type t2.small \
+    --private-ip-address "10.240.0.1$i" \
+    --subnet-id "$SUBNET_ID" \
+    --user-data "name=controller-$i" \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=controller-$i},{Key=kubernetes.io/cluster/kubernetes-the-hard-way,Value=shared}]" \
+    --profile kubernetes-the-hard-way \
+    --query 'Instances[].InstanceId' \
+    --output text)"
+
+  aws ec2 modify-instance-attribute \
+    --instance-id "$instance_id" \
+    --no-source-dest-check \
+    --profile kubernetes-the-hard-way
+done
+```
+
+</details>
+
 ### Kubernetes Workers
 
 Each worker instance requires a pod subnet allocation from the Kubernetes cluster CIDR range. The pod subnet allocation will be used to configure container networking in a later exercise. The `pod-cidr` instance metadata will be used to expose pod subnet allocations to compute instances at runtime.
@@ -121,6 +514,9 @@ Each worker instance requires a pod subnet allocation from the Kubernetes cluste
 > The Kubernetes cluster CIDR range is defined by the Controller Manager's `--cluster-cidr` flag. In this tutorial the cluster CIDR range will be set to `10.200.0.0/16`, which supports 254 subnets.
 
 Create three compute instances which will host the Kubernetes worker nodes:
+
+<details open>
+<summary>GCP</summary>
 
 ```
 for i in 0 1 2; do
@@ -139,9 +535,44 @@ for i in 0 1 2; do
 done
 ```
 
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+for i in 0 1 2; do
+  instance_id="$(aws ec2 run-instances \
+    --associate-public-ip-address \
+    --iam-instance-profile Name=kubernetes-the-hard-way \
+    --image-id "$IMAGE_ID" \
+    --count 1 \
+    --key-name kubernetes-the-hard-way \
+    --security-group-ids "$SECURITY_GROUP_ID" \
+    --instance-type t2.small \
+    --private-ip-address "10.240.0.2$i" \
+    --subnet-id "$SUBNET_ID" \
+    --user-data "name=worker-$i|pod-cidr=10.200.$i.0/24" \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=worker-$i},{Key=kubernetes.io/cluster/kubernetes-the-hard-way,Value=shared}]" \
+    --profile kubernetes-the-hard-way \
+    --query 'Instances[].InstanceId' \
+    --output text)"
+
+  aws ec2 modify-instance-attribute \
+    --instance-id "$instance_id" \
+    --no-source-dest-check \
+    --profile kubernetes-the-hard-way
+done
+```
+
+</details>
+
 ### Verification
 
 List the compute instances in your default compute zone:
+
+<details open>
+<summary>GCP</summary>
 
 ```
 gcloud compute instances list
@@ -159,7 +590,42 @@ worker-1      us-west1-c  n1-standard-1               10.240.0.21  XX.XXX.XX.XXX
 worker-2      us-west1-c  n1-standard-1               10.240.0.22  XXX.XXX.XX.XX   RUNNING
 ```
 
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+aws ec2 describe-instances \
+  --filters \
+    Name=instance-state-name,Values=running \
+    Name=vpc-id,Values="$VPC_ID" \
+  --profile kubernetes-the-hard-way \
+  --query 'Reservations[].Instances[]|sort_by(@, &Tags[?Key==`Name`]|[0].Value)[].[Tags[?Key==`Name`]|[0].Value,InstanceId,Placement.AvailabilityZone,PrivateIpAddress,PublicIpAddress]' \
+  --output table
+```
+
+> output
+
+```
+----------------------------------------------------------------------------------------
+|                                   DescribeInstances                                  |
++--------------+-----------------------+-------------+--------------+------------------+
+|  controller-0|  i-07c33497b7e6ee5ce  |  us-west-2a |  10.240.0.10 |  34.216.239.194  |
+|  controller-1|  i-099ffe8ec525f6bdb  |  us-west-2a |  10.240.0.11 |  54.186.157.115  |
+|  controller-2|  i-00c1800423320d12f  |  us-west-2a |  10.240.0.12 |  52.12.162.200   |
+|  worker-0    |  i-00020c75b6703aa99  |  us-west-2a |  10.240.0.20 |  54.212.17.18    |
+|  worker-1    |  i-0bf4c8f9f36012d0e  |  us-west-2a |  10.240.0.21 |  34.220.143.249  |
+|  worker-2    |  i-0b4d2dd686ddd1e1a  |  us-west-2a |  10.240.0.22 |  35.165.251.149  |
++--------------+-----------------------+-------------+--------------+------------------+
+```
+
+</details>
+
 ## Configuring SSH Access
+
+<details open>
+<summary>GCP</summary>
 
 SSH will be used to configure the controller and worker instances. When connecting to compute instances for the first time SSH keys will be generated for you and stored in the project or instance metadata as describe in the [connecting to instances](https://cloud.google.com/compute/docs/instances/connecting-to-instance) documentation.
 
@@ -226,5 +692,28 @@ $USER@controller-0:~$ exit
 logout
 Connection to XX.XXX.XXX.XXX closed
 ```
+
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+get_ip() {
+  aws ec2 describe-instances \
+    --filters \
+      Name=vpc-id,Values="$VPC_ID" \
+      Name=tag:Name,Values="$1" \
+    --profile kubernetes-the-hard-way \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' \
+    --output text
+}
+```
+```
+ssh -i ~/.ssh/kubernetes-the-hard-way "ubuntu@$(get_ip controller-0)"
+```
+
+</details>
+<p></p>
 
 Next: [Provisioning a CA and Generating TLS Certificates](04-certificate-authority.md)

--- a/docs/05-kubernetes-configuration-files.md
+++ b/docs/05-kubernetes-configuration-files.md
@@ -12,17 +12,38 @@ Each kubeconfig requires a Kubernetes API Server to connect to. To support high 
 
 Retrieve the `kubernetes-the-hard-way` static IP address:
 
+<details open>
+<summary>GCP</summary>
+
 ```
 KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
   --region $(gcloud config get-value compute/region) \
   --format 'value(address)')
 ```
 
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+KUBERNETES_PUBLIC_ADDRESS="$(aws elb describe-load-balancers \
+  --load-balancer-name kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way \
+  --query 'LoadBalancerDescriptions[0].DNSName' \
+  --output text)"
+```
+
+</details>
+
 ### The kubelet Kubernetes Configuration File
 
 When generating kubeconfig files for Kubelets the client certificate matching the Kubelet's node name must be used. This will ensure Kubelets are properly authorized by the Kubernetes [Node Authorizer](https://kubernetes.io/docs/admin/authorization/node/).
 
 Generate a kubeconfig file for each worker node:
+
+<details open>
+<summary>GCP</summary>
 
 ```
 for instance in worker-0 worker-1 worker-2; do
@@ -46,6 +67,41 @@ for instance in worker-0 worker-1 worker-2; do
   kubectl config use-context default --kubeconfig=${instance}.kubeconfig
 done
 ```
+
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+for i in 0 1 2; do
+  instance="worker-$i"
+  hostname="ip-10-240-0-2$i"
+
+  kubectl config set-cluster kubernetes-the-hard-way \
+    --certificate-authority=ca.pem \
+    --embed-certs=true \
+    --server="https://$KUBERNETES_PUBLIC_ADDRESS:6443" \
+    --kubeconfig="$instance.kubeconfig"
+
+  kubectl config set-credentials "system:node:$hostname" \
+    --client-certificate="$instance.pem" \
+    --client-key="$instance-key.pem" \
+    --embed-certs=true \
+    --kubeconfig="$instance.kubeconfig"
+
+  kubectl config set-context default \
+    --cluster=kubernetes-the-hard-way \
+    --user="system:node:$hostname" \
+    --kubeconfig="$instance.kubeconfig"
+
+  kubectl config use-context default \
+    --kubeconfig="$instance.kubeconfig"
+done
+```
+
+</details>
+<p></p>
 
 Results:
 
@@ -195,18 +251,72 @@ admin.kubeconfig
 
 Copy the appropriate `kubelet` and `kube-proxy` kubeconfig files to each worker instance:
 
+<details open>
+<summary>GCP</summary>
+
 ```
 for instance in worker-0 worker-1 worker-2; do
   gcloud compute scp ${instance}.kubeconfig kube-proxy.kubeconfig ${instance}:~/
 done
 ```
 
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+VPC_ID="$(aws ec2 describe-vpcs \
+  --filters Name=tag-key,Values=kubernetes.io/cluster/kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way \
+  --query 'Vpcs[0].VpcId' \
+  --output text)"
+
+get_ip() {
+  aws ec2 describe-instances \
+    --filters \
+      Name=vpc-id,Values="$VPC_ID" \
+      Name=tag:Name,Values="$1" \
+    --profile kubernetes-the-hard-way \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' \
+    --output text
+}
+```
+```
+for instance in worker-0 worker-1 worker-2; do
+  scp -i ~/.ssh/kubernetes-the-hard-way -o StrictHostKeyChecking=no \
+    "$instance.kubeconfig" kube-proxy.kubeconfig "ubuntu@$(get_ip "$instance"):~/"
+done
+```
+
+</details>
+<p></p>
+
 Copy the appropriate `kube-controller-manager` and `kube-scheduler` kubeconfig files to each controller instance:
+
+<details open>
+<summary>GCP</summary>
 
 ```
 for instance in controller-0 controller-1 controller-2; do
   gcloud compute scp admin.kubeconfig kube-controller-manager.kubeconfig kube-scheduler.kubeconfig ${instance}:~/
 done
 ```
+
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+for instance in controller-0 controller-1 controller-2; do
+  scp -i ~/.ssh/kubernetes-the-hard-way -o StrictHostKeyChecking=no \
+    admin.kubeconfig kube-controller-manager.kubeconfig kube-scheduler.kubeconfig \
+    "ubuntu@$(get_ip "$instance"):~/"
+done
+```
+
+</details>
+<p></p>
 
 Next: [Generating the Data Encryption Config and Key](06-data-encryption-keys.md)

--- a/docs/06-data-encryption-keys.md
+++ b/docs/06-data-encryption-keys.md
@@ -34,10 +34,45 @@ EOF
 
 Copy the `encryption-config.yaml` encryption config file to each controller instance:
 
+<details open>
+<summary>GCP</summary>
+
 ```
 for instance in controller-0 controller-1 controller-2; do
   gcloud compute scp encryption-config.yaml ${instance}:~/
 done
 ```
+
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+VPC_ID="$(aws ec2 describe-vpcs \
+  --filters Name=tag-key,Values=kubernetes.io/cluster/kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way \
+  --query 'Vpcs[0].VpcId' \
+  --output text)"
+
+get_ip() {
+  aws ec2 describe-instances \
+    --filters \
+      Name=vpc-id,Values="$VPC_ID" \
+      Name=tag:Name,Values="$1" \
+    --profile kubernetes-the-hard-way \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' \
+    --output text
+}
+```
+```
+for instance in controller-0 controller-1 controller-2; do
+  scp -i ~/.ssh/kubernetes-the-hard-way -o StrictHostKeyChecking=no \
+    encryption-config.yaml "ubuntu@$(get_ip "$instance"):~/"
+done
+```
+
+</details>
+<p></p>
 
 Next: [Bootstrapping the etcd Cluster](07-bootstrapping-etcd.md)

--- a/docs/10-configuring-kubectl.md
+++ b/docs/10-configuring-kubectl.md
@@ -10,6 +10,9 @@ Each kubeconfig requires a Kubernetes API Server to connect to. To support high 
 
 Generate a kubeconfig file suitable for authenticating as the `admin` user:
 
+<details open>
+<summary>GCP</summary>
+
 ```
 {
   KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
@@ -32,6 +35,36 @@ Generate a kubeconfig file suitable for authenticating as the `admin` user:
   kubectl config use-context kubernetes-the-hard-way
 }
 ```
+
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+KUBERNETES_PUBLIC_ADDRESS="$(aws elb describe-load-balancers \
+  --load-balancer-name kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way \
+  --query 'LoadBalancerDescriptions[0].DNSName' \
+  --output text)"
+
+kubectl config set-cluster kubernetes-the-hard-way \
+  --certificate-authority=ca.pem \
+  --embed-certs=true \
+  --server="https://$KUBERNETES_PUBLIC_ADDRESS:6443"
+
+kubectl config set-credentials admin \
+  --client-certificate=admin.pem \
+  --client-key=admin-key.pem
+
+kubectl config set-context kubernetes-the-hard-way \
+  --cluster=kubernetes-the-hard-way \
+  --user=admin
+
+kubectl config use-context kubernetes-the-hard-way
+```
+
+</details>
 
 ## Verification
 

--- a/docs/11-pod-network-routes.md
+++ b/docs/11-pod-network-routes.md
@@ -12,12 +12,59 @@ In this section you will gather the information required to create routes in the
 
 Print the internal IP address and Pod CIDR range for each worker instance:
 
+<details open>
+<summary>GCP</summary>
+
 ```
 for instance in worker-0 worker-1 worker-2; do
   gcloud compute instances describe ${instance} \
     --format 'value[separator=" "](networkInterfaces[0].networkIP,metadata.items[0].value)'
 done
 ```
+
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+VPC_ID="$(aws ec2 describe-vpcs \
+  --filters Name=tag-key,Values=kubernetes.io/cluster/kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way \
+  --query 'Vpcs[0].VpcId' \
+  --output text)"
+```
+```
+for i in 0 1 2; do
+  instance_id="$(aws ec2 describe-instances \
+    --filters \
+      Name=vpc-id,Values="$VPC_ID" \
+      Name=tag:Name,Values="worker-$i" \
+    --profile kubernetes-the-hard-way \
+    --query 'Reservations[0].Instances[0].InstanceId' \
+    --output text)"
+
+  instance_ip="$(aws ec2 describe-instances \
+    --instance-ids "$instance_id" \
+    --profile kubernetes-the-hard-way \
+    --query 'Reservations[0].Instances[0].PrivateIpAddress' \
+    --output text)"
+
+  instance_ud="$(aws ec2 describe-instance-attribute \
+    --instance-id "$instance_id" \
+    --attribute userData \
+    --profile kubernetes-the-hard-way \
+    --query UserData.Value \
+    --output text|base64 --decode)"
+
+  pod_cidr="$(echo "$instance_ud"|tr '|' '\n'|grep '^pod-cidr='|cut -d= -f2)"
+
+  echo "$instance_ip $pod_cidr"
+done
+```
+
+</details>
+<p></p>
 
 > output
 
@@ -31,6 +78,9 @@ done
 
 Create network routes for each worker instance:
 
+<details open>
+<summary>GCP</summary>
+
 ```
 for i in 0 1 2; do
   gcloud compute routes create kubernetes-route-10-200-${i}-0-24 \
@@ -40,13 +90,78 @@ for i in 0 1 2; do
 done
 ```
 
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+ROUTE_TABLE_ID="$(aws ec2 describe-route-tables \
+  --filters \
+    Name=vpc-id,Values="$VPC_ID" \
+    Name=tag-key,Values=kubernetes.io/cluster/kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way \
+  --query 'RouteTables[0].RouteTableId' \
+  --output text)"
+
+for i in 0 1 2; do
+  instance_id="$(aws ec2 describe-instances \
+    --filters \
+      Name=vpc-id,Values="$VPC_ID" \
+      Name=tag:Name,Values="worker-$i" \
+    --profile kubernetes-the-hard-way \
+    --query 'Reservations[0].Instances[0].InstanceId' \
+    --output text)"
+
+  instance_ud="$(aws ec2 describe-instance-attribute \
+    --instance-id "$instance_id" \
+    --attribute userData \
+    --profile kubernetes-the-hard-way \
+    --query UserData.Value \
+    --output text|base64 --decode)"
+
+  pod_cidr="$(echo "$instance_ud"|tr '|' '\n'|grep '^pod-cidr='|cut -d= -f2)"
+
+  aws ec2 create-route \
+    --route-table-id "$ROUTE_TABLE_ID" \
+    --destination-cidr-block "$pod_cidr" \
+    --instance-id "$instance_id" \
+    --profile kubernetes-the-hard-way
+done
+```
+
+</details>
+<p></p>
+
 List the routes in the `kubernetes-the-hard-way` VPC network:
+
+<details open>
+<summary>GCP</summary>
 
 ```
 gcloud compute routes list --filter "network: kubernetes-the-hard-way"
 ```
 
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+aws ec2 describe-route-tables \
+  --route-table-id "$ROUTE_TABLE_ID" \
+  --profile kubernetes-the-hard-way \
+  --query 'RouteTables[0].Routes[]|sort_by(@, &DestinationCidrBlock)[].[InstanceId,DestinationCidrBlock,GatewayId]' \
+  --output table
+```
+
+</details>
+<p></p>
+
 > output
+
+<details open>
+<summary>GCP</summary>
 
 ```
 NAME                            NETWORK                  DEST_RANGE     NEXT_HOP                  PRIORITY
@@ -56,5 +171,25 @@ kubernetes-route-10-200-0-0-24  kubernetes-the-hard-way  10.200.0.0/24  10.240.0
 kubernetes-route-10-200-1-0-24  kubernetes-the-hard-way  10.200.1.0/24  10.240.0.21               1000
 kubernetes-route-10-200-2-0-24  kubernetes-the-hard-way  10.200.2.0/24  10.240.0.22               1000
 ```
+
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+----------------------------------------------------------
+|                   DescribeRouteTables                  |
++---------------------+-----------------+----------------+
+|  None               |  0.0.0.0/0      |  igw-116a3177  |
+|  i-0d173dd08280c9f52|  10.200.0.0/24  |  None          |
+|  i-0a4ae7e79b0bc3cc9|  10.200.1.0/24  |  None          |
+|  i-0a424b69034b9068f|  10.200.2.0/24  |  None          |
+|  None               |  10.240.0.0/24  |  local         |
++---------------------+-----------------+----------------+
+```
+
+</details>
+<p></p>
 
 Next: [Deploying the DNS Cluster Add-on](12-dns-addon.md)

--- a/docs/14-cleanup.md
+++ b/docs/14-cleanup.md
@@ -2,6 +2,9 @@
 
 In this lab you will delete the compute resources created during this tutorial.
 
+<details open>
+<summary>GCP</summary>
+
 ## Compute Instances
 
 Delete the controller and worker compute instances:
@@ -53,3 +56,117 @@ Delete the `kubernetes-the-hard-way` network VPC:
   gcloud -q compute networks delete kubernetes-the-hard-way
 }
 ```
+
+</details>
+
+<details>
+<summary>AWS</summary>
+
+```
+VPC_ID="$(aws ec2 describe-vpcs \
+  --filters Name=tag-key,Values=kubernetes.io/cluster/kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way \
+  --query 'Vpcs[0].VpcId' \
+  --output text)"
+```
+```
+for host in controller-0 controller-1 controller-2 worker-0 worker-1 worker-2; do
+  INSTANCE_ID="$(aws ec2 describe-instances \
+    --filters \
+      Name=vpc-id,Values="$VPC_ID" \
+      Name=tag:Name,Values="$host" \
+    --profile kubernetes-the-hard-way \
+    --query 'Reservations[].Instances[].InstanceId' \
+    --output text)"
+
+  aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" --profile kubernetes-the-hard-way
+done
+
+aws iam remove-role-from-instance-profile \
+  --instance-profile-name kubernetes-the-hard-way \
+  --role-name kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way
+
+aws iam delete-instance-profile \
+  --instance-profile-name kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way
+
+aws iam delete-role-policy \
+  --role-name kubernetes-the-hard-way \
+  --policy-name kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way
+
+aws iam delete-role \
+  --role-name kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way
+
+aws ec2 delete-key-pair \
+  --key-name kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way
+
+# After all ec2 instances have been terminated.
+aws elb delete-load-balancer \
+  --load-balancer-name kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way
+
+INTERNET_GATEWAY_ID="$(aws ec2 describe-internet-gateways \
+  --filter Name=tag-key,Values=kubernetes.io/cluster/kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way \
+  --query 'InternetGateways[0].InternetGatewayId' \
+  --output text)"
+
+aws ec2 detach-internet-gateway \
+  --internet-gateway-id "$INTERNET_GATEWAY_ID" \
+  --vpc-id "$VPC_ID" \
+  --profile kubernetes-the-hard-way
+
+aws ec2 delete-internet-gateway \
+  --internet-gateway-id "$INTERNET_GATEWAY_ID" \
+  --profile kubernetes-the-hard-way
+
+SECURITY_GROUP_ID="$(aws ec2 describe-security-groups \
+  --filters Name=group-name,Values=kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way \
+  --query 'SecurityGroups[0].GroupId' \
+  --output text)"
+
+aws ec2 delete-security-group \
+  --group-id "$SECURITY_GROUP_ID" \
+  --profile kubernetes-the-hard-way
+
+SUBNET_ID="$(aws ec2 describe-subnets \
+  --filters Name=tag-key,Values=kubernetes.io/cluster/kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way \
+  --query 'Subnets[0].SubnetId' \
+  --output text)"
+
+aws ec2 delete-subnet \
+  --subnet-id "$SUBNET_ID" \
+  --profile kubernetes-the-hard-way
+
+ROUTE_TABLE_ID="$(aws ec2 describe-route-tables \
+  --filter Name=tag-key,Values=kubernetes.io/cluster/kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way \
+  --query 'RouteTables[0].RouteTableId' \
+  --output text)"
+
+aws ec2 delete-route-table \
+  --route-table-id "$ROUTE_TABLE_ID" \
+  --profile kubernetes-the-hard-way
+
+aws ec2 delete-vpc \
+  --vpc-id "$VPC_ID" \
+  --profile kubernetes-the-hard-way
+
+DHCP_OPTION_SET_ID="$(aws ec2 describe-dhcp-options \
+  --filters Name=tag-key,Values=kubernetes.io/cluster/kubernetes-the-hard-way \
+  --profile kubernetes-the-hard-way \
+  --query 'DhcpOptions[0].DhcpOptionsId' \
+  --output text)"
+
+aws ec2 delete-dhcp-options \
+  --dhcp-options-id "$DHCP_OPTION_SET_ID" \
+  --profile kubernetes-the-hard-way
+```
+
+</details>


### PR DESCRIPTION
This PR reintroduces AWS as an alternative to GCP.

It does so by putting GCP code in collapsible/expanded sections marked GCP and adding expandable/collapsed sections marked AWS, so code for each can be easily viewed, without splitting chapters into separate files and without decreasing readability for those who only care about the GCP version.

Why go into all this trouble ? The free trial for GCP on my private account ran out and on my work account I couldn't sign up for it, because `You don’t have permission to create a billing account for your organization`.

The AWS code is mostly reused from git history, with some minor differences:
* A dedicated aws profile is used throughout the tutorial, to avoid messing with the user's defaults
* The cluster name was changed from `kubernetes` to `kubernetes-the-hard-way` (the old name seemed too generic and I already had other clusters running on that account)
* The tags used follow the AWS provider convention - `kubernetes.io/cluster/<cluster name>`, instead of the original `kubernetes`
* No state is expected to be present in the user's shell when starting a new chapter (`VPC_ID` and `get_ip()` occur in most and are redefined on first occurrence in each chapter)
* The use of `ssh-agent` and `jq` was dropped
* Quoting was added to shell code

Otherwise, I kept the AWS code as close the the GCP version, as possible and avoided shell-specific constructs.

If you don't want to reintroduce AWS code, that's ok, it will just stay in my fork. I don't expect to update it though.
If you do want to merge this, I can make any changes you think are needed.

Cheers