### PR TITLE
Fix ownership on /usr/local/bin/etcd* files

### DIFF
--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -31,6 +31,7 @@ Extract and install the `etcd` server and the `etcdctl` command line utility:
 {
   tar -xvf etcd-v3.3.5-linux-amd64.tar.gz
   sudo mv etcd-v3.3.5-linux-amd64/etcd* /usr/local/bin/
+  sudo chown root:root /usr/local/bin/etcd*
 }
 ```
 

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -40,6 +40,7 @@ Install the Kubernetes binaries:
 {
   chmod +x kube-apiserver kube-controller-manager kube-scheduler kubectl
   sudo mv kube-apiserver kube-controller-manager kube-scheduler kubectl /usr/local/bin/
+  sudo chown root:root /usr/local/bin/kube*
 }
 ```
 
@@ -52,6 +53,8 @@ Install the Kubernetes binaries:
   sudo mv ca.pem ca-key.pem kubernetes-key.pem kubernetes.pem \
     service-account-key.pem service-account.pem \
     encryption-config.yaml /var/lib/kubernetes/
+
+  sudo chown root:root /var/lib/kubernetes/*
 }
 ```
 


### PR DESCRIPTION
Not doing so leaves the ownership of the etcd binaries to the GCP user:

```
patrick@controller-1:~$ sudo mv etcd-v3.3.9-linux-amd64/etcd* /usr/local/bin/
patrick@controller-1:~$ ll /usr/local/bin/
total 33940
drwxr-xr-x  2 root    root        4096 Aug  8 17:25 ./
drwxr-xr-x 10 root    root        4096 Aug  6 20:34 ../
-rwxr-xr-x  1 patrick patrick 18934016 Jul 24 17:13 etcd*
-rwxr-xr-x  1 patrick patrick 15809280 Jul 24 17:13 etcdctl*
```