### PR TITLE
Fixing #356 DNS resolution with latest busybox

### DIFF
--- a/docs/12-dns-addon.md
+++ b/docs/12-dns-addon.md
@@ -37,7 +37,7 @@ kube-dns-3097350089-gq015   3/3       Running   0          20s
 Create a `busybox` deployment:
 
 ```
-kubectl run busybox --image=busybox --command -- sleep 3600
+kubectl run busybox --image=busybox:1.28.4 --command -- sleep 3600
 ```
 
 List the pod created by the `busybox` deployment:


### PR DESCRIPTION
Version `1.28.4` of busybox does the `nslookup` correctly as described in the tutorial, the `latest` does not. So it needs to be set explicitely. Fixes https://github.com/kelseyhightower/kubernetes-the-hard-way/issues/356. Also see https://github.com/docker-library/busybox/issues/48.