### PR TITLE
--show-progress and --https-only options not supported in older versi…

### DIFF
--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -33,21 +33,16 @@ brew install cfssl
 ### Linux
 
 ```
-wget -q --show-progress --https-only --timestamping \
-  https://pkg.cfssl.org/R1.2/cfssl_linux-amd64 \
-  https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
+curl -o cfssl https://pkg.cfssl.org/R1.2/cfssl_linux-amd64 
+curl -o cfssljson https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
 ```
 
 ```
-chmod +x cfssl_linux-amd64 cfssljson_linux-amd64
+chmod +x cfssl cfssljson
 ```
 
 ```
-sudo mv cfssl_linux-amd64 /usr/local/bin/cfssl
-```
-
-```
-sudo mv cfssljson_linux-amd64 /usr/local/bin/cfssljson
+sudo mv cfssl cfssljson /usr/local/bin/
 ```
 
 ### Verification


### PR DESCRIPTION
…ons of wget

In older version of wget (v1.14), --show-progress and --https-only options are not available.
I have experienced the error in CentOS Linux release 7.4.1708.

Also, it's better to use curl instead, as in some of the Linux distributions wget not pre-installed.