### PR TITLE
add "name" to /etc/cni/net.d/99-loopback.conf

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -103,6 +103,7 @@ Create the `loopback` network configuration file:
 cat <<EOF | sudo tee /etc/cni/net.d/99-loopback.conf
 {
     "cniVersion": "0.3.1",
+    "name": "lo",
     "type": "loopback"
 }
 EOF


### PR DESCRIPTION
For the latest cni version, name is mandatory, otherwise cni will
complain "missing network name".