### PR TITLE
Don't use -C option in tar, extract and mv instead

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -63,7 +63,8 @@ Install the worker binaries:
   sudo mv kubectl kube-proxy kubelet runc runsc /usr/local/bin/
   sudo tar -xvf crictl-v1.12.0-linux-amd64.tar.gz -C /usr/local/bin/
   sudo tar -xvf cni-plugins-amd64-v0.6.0.tgz -C /opt/cni/bin/
-  sudo tar -xvf containerd-1.2.0-rc.0.linux-amd64.tar.gz -C /
+  tar --strip-components=1 -xvf containerd-1.2.0-rc.0.linux-amd64.tar.gz
+  sudo mv containerd containerd-release containerd-shim containerd-shim-runc-v1 containerd-stress ctr /bin
 }
 ```
 


### PR DESCRIPTION
That `tar -xvf containerd-1.2.0-rc.0.linux-amd64.tar.gz -C /bin` cleans out `/bin` before extracting on CentOS 7, leaving the system in a useless state (`ls`? Who needs `ls`?). Instead, this extracts the files and moves them to their new spot much like the other commands in this step.