### PR TITLE
Use RuntimeClass for supporting sandboxed pods

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -100,6 +100,7 @@ ExecStart=/usr/local/bin/kube-apiserver \\
   --service-node-port-range=30000-32767 \\
   --tls-cert-file=/var/lib/kubernetes/kubernetes.pem \\
   --tls-private-key-file=/var/lib/kubernetes/kubernetes-key.pem \\
+  --feature-gates=RuntimeClass=true \\
   --v=2
 Restart=on-failure
 RestartSec=5
@@ -332,6 +333,35 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: kubernetes
+EOF
+```
+
+## Configure the RuntimeClass Custom Resource for gVisor
+
+The [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/)
+custom resource allows you to discover supported runtimes in your cluster and
+specify a specific runtime per pod. In this lab you will use it to create pods
+that can be run using gVisor.
+
+The runtime class API is in *Alpha* so it is not a built-in resource yet. You will
+need a custom resource definition to use it.  First create the custom resource
+definition.
+
+```
+kubectl apply --kubeconfig admin.kubeconfig \
+    -f https://raw.githubusercontent.com/kubernetes/kubernetes/v1.12.0/cluster/addons/runtimeclass/runtimeclass_crd.yaml
+```
+
+Create the runtime class for gVisor.
+
+```
+cat <<EOF | kubectl apply --kubeconfig admin.kubeconfig -f -
+apiVersion: node.k8s.io/v1alpha1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+spec:
+  runtimeHandler: runsc
 EOF
 ```
 

--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -221,9 +221,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: untrusted
-  annotations:
-    io.kubernetes.cri.untrusted-workload: "true"
 spec:
+  runtimeClassName: gvisor
   containers:
     - name: webserver
       image: gcr.io/hightowerlabs/helloworld:2.0.0


### PR DESCRIPTION
Update the lab to use RuntimeClass as the way to specify pods that should be run in gVisor rather than the untrusted-workload annotation.