### PR TITLE
Running kubelet fails when swap is on

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -222,6 +222,7 @@ ExecStart=/usr/local/bin/kubelet \\
   --kubeconfig=/var/lib/kubelet/kubeconfig \\
   --network-plugin=cni \\
   --register-node=true \\
+  --fail-swap-on=false \\
   --v=2
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
When running on a fresh ubuntu 16.04 / linux image swap is enabled, this prevents kubelet from starting.