### PR TITLE
Fix nginx dependencies not found because apt not updated

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -209,7 +209,10 @@ A [Google Network Load Balancer](https://cloud.google.com/compute/docs/load-bala
 Install a basic web server to handle HTTP health checks:
 
 ```
-sudo apt-get install -y nginx
+{
+  sudo apt-get update
+  sudo apt-get install -y nginx
+}
 ```
 
 ```


### PR DESCRIPTION
Small bug, apt not refreshed before [nginx install](https://github.com/kelseyhightower/kubernetes-the-hard-way/blob/master/docs/09-bootstrapping-kubernetes-workers.md#provisioning-a-kubernetes-worker-node).
On the next page in [chapter 09](https://github.com/kelseyhightower/kubernetes-the-hard-way/blob/master/docs/08-bootstrapping-kubernetes-controllers.md#enable-http-health-checks), an apt-get update is anready included.