### PR TITLE
Added portmap cni plugin

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -79,21 +79,30 @@ POD_CIDR=$(curl -s -H "Metadata-Flavor: Google" \
 Create the `bridge` network configuration file:
 
 ```
-cat <<EOF | sudo tee /etc/cni/net.d/10-bridge.conf
+cat <<EOF | sudo tee /etc/cni/net.d/10-bridge.conflist
 {
-    "cniVersion": "0.3.1",
-    "name": "bridge",
-    "type": "bridge",
-    "bridge": "cnio0",
-    "isGateway": true,
-    "ipMasq": true,
-    "ipam": {
+  "cniVersion": "0.3.1",
+  "name": "bridge",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cnio0",
+      "isGateway": true,
+      "ipMasq": true,
+      "ipam": {
         "type": "host-local",
         "ranges": [
           [{"subnet": "${POD_CIDR}"}]
         ],
         "routes": [{"dst": "0.0.0.0/0"}]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true},
+      "snat": true
     }
+  ]
 }
 EOF
 ```


### PR DESCRIPTION
Added CNI `portmap` plugin to allow for `hostPort` in Pod definitions. We could put this in a separate CNI configuration file but i decided to keep both portmap and bridge plugins in one `conflist`. Don't know what you think but it works.