### PR TITLE
Update 08-bootstrapping-kubernetes-controllers.md

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -335,6 +335,8 @@ subjects:
 EOF
 ```
 
+> Remember to run the above commands on each controller node: `controller-0`, `controller-1`, and `controller-2`.
+
 ## The Kubernetes Frontend Load Balancer
 
 In this section you will provision an external load balancer to front the Kubernetes API Servers. The `kubernetes-the-hard-way` static IP address will be attached to the resulting load balancer.


### PR DESCRIPTION
Clarified that the RBAC for Kubelet Authorization Section needs to be run on all three controller nodes.

I haven't completed the tutorial with only running the RBAC for Kubelet Authorization Section on controller-0, but I suspect that just doing this on controller-0 will cause problems if the load balancer sends requests to other controller nodes.