### PR TITLE
Add zone to cleanup command

### DIFF
--- a/docs/14-cleanup.md
+++ b/docs/14-cleanup.md
@@ -7,7 +7,7 @@ In this lab you will delete the compute resources created during this tutorial.
 Delete the controller and worker compute instances:
 
 ```
-gcloud -q compute instances delete \
+gcloud -q compute instances delete --zone $(gcloud config get-value compute/zone) \
   controller-0 controller-1 controller-2 \
   worker-0 worker-1 worker-2
 ```


### PR DESCRIPTION
When I ran the command as described in the tutorial I got the following:

```
ERROR: (gcloud.compute.instances.delete) Underspecified resource [controller-0, controller-1, controller-2, worker-0, worker-1, worker-2]. Specify the [--zone] flag.
```
I believe I do have gcloud set up correctly (although, perhaps I'm wrong)

```bash
> gcloud config list compute/zone
[compute]
zone = us-central1-a
```