### PR TITLE
kube-scheduler change api version as the current is unsupported

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -159,7 +159,7 @@ Create the `kube-scheduler.yaml` configuration file:
 
 ```
 cat <<EOF | sudo tee /etc/kubernetes/config/kube-scheduler.yaml
-apiVersion: componentconfig/v1alpha1
+apiVersion: kubescheduler.config.k8s.io/v1alpha1
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: "/var/lib/kubernetes/kube-scheduler.kubeconfig"


### PR DESCRIPTION
Logs that confirm this change:
```
WARNING: the provided config file is an unsupported apiVersion ("componentconfig/v1alpha1"), which will be removed in future releases

WARNING: switch to command-line flags or update your config file apiVersion to "kubescheduler.config.k8s.io/v1alpha1"

WARNING: apiVersions at alpha-level are not guaranteed to be supported in future releases
```