### PR TITLE
Update 01-prerequisites.md

### DIFF
--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -42,6 +42,7 @@ Set a default compute zone:
 gcloud config set compute/zone us-west1-c
 ```
 
+> Use the `gcloud auth login` to authenticate with the Google Cloud SDK.
 > Use the `gcloud compute zones list` command to view additional regions and zones.
 
 ## Running Commands in Parallel with tmux


### PR DESCRIPTION
The `gcloud compute zones list` command will return following error if it's not authenticated with the Google Cloud SDK.
```
ERROR: (gcloud.compute.zones.list) Some requests did not succeed:
 - Failed to find project [Project ID]
```