### PR TITLE
Update to Kubernetes v1.14.4 with necessary fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ The target audience for this tutorial is someone planning to support a productio
 
 Kubernetes The Hard Way guides you through bootstrapping a highly available Kubernetes cluster with end-to-end encryption between components and RBAC authentication.
 
-* [Kubernetes](https://github.com/kubernetes/kubernetes) 1.12.0
-* [containerd Container Runtime](https://github.com/containerd/containerd) 1.2.0-rc.0
-* [gVisor](https://github.com/google/gvisor) 50c283b9f56bb7200938d9e207355f05f79f0d17
-* [CNI Container Networking](https://github.com/containernetworking/cni) 0.6.0
-* [etcd](https://github.com/coreos/etcd) v3.3.9
-* [CoreDNS](https://github.com/coredns/coredns) v1.2.2
+* [Kubernetes](https://github.com/kubernetes/kubernetes) v1.14.4
+* [containerd Container Runtime](https://github.com/containerd/containerd) 1.2.7
+* [gVisor](https://github.com/google/gvisor) release-20190529.1
+* [CNI Container Networking](https://github.com/containernetworking/cni) 0.7.1
+* [etcd](https://github.com/coreos/etcd) v3.3.13
+* [CoreDNS](https://github.com/coredns/coredns) v1.5.2
+* [cri-tools](https://github.com/kubernetes-sigs/cri-tools) v1.15.0
+* [runc](https://github.com/opencontainers/runc) v1.0.0-rc8
+* [CNI plugins](https://github.com/containernetworking/plugins) v0.8.1
 
 ## Labs
 

--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -16,8 +16,17 @@ Follow the Google Cloud SDK [documentation](https://cloud.google.com/sdk/) to in
 
 Verify the Google Cloud SDK version is 218.0.0 or higher:
 
-```
+```sh
 gcloud version
+```
+
+> output
+
+```
+Google Cloud SDK 241.0.0
+bq 2.0.43
+core 2019.04.02
+gsutil 4.38
 ```
 
 ### Set a Default Compute Region and Zone
@@ -26,19 +35,19 @@ This tutorial assumes a default compute region and zone have been configured.
 
 If you are using the `gcloud` command-line tool for the first time `init` is the easiest way to do this:
 
-```
+```sh
 gcloud init
 ```
 
 Otherwise set a default compute region:
 
-```
+```sh
 gcloud config set compute/region us-west1
 ```
 
 Set a default compute zone:
 
-```
+```sh
 gcloud config set compute/zone us-west1-c
 ```
 

--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -11,42 +11,42 @@ Download and install `cfssl` and `cfssljson` from the [cfssl repository](https:/
 
 ### OS X
 
-```
+```sh
 curl -o cfssl https://pkg.cfssl.org/R1.2/cfssl_darwin-amd64
 curl -o cfssljson https://pkg.cfssl.org/R1.2/cfssljson_darwin-amd64
 ```
 
-```
+```sh
 chmod +x cfssl cfssljson
 ```
 
-```
+```sh
 sudo mv cfssl cfssljson /usr/local/bin/
 ```
 
 Some OS X users may experience problems using the pre-built binaries in which case [Homebrew](https://brew.sh) might be a better option:
 
-```
+```sh
 brew install cfssl
 ```
 
 ### Linux
 
-```
+```sh
 wget -q --show-progress --https-only --timestamping \
   https://pkg.cfssl.org/R1.2/cfssl_linux-amd64 \
   https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
 ```
 
-```
+```sh
 chmod +x cfssl_linux-amd64 cfssljson_linux-amd64
 ```
 
-```
+```sh
 sudo mv cfssl_linux-amd64 /usr/local/bin/cfssl
 ```
 
-```
+```sh
 sudo mv cfssljson_linux-amd64 /usr/local/bin/cfssljson
 ```
 
@@ -54,64 +54,65 @@ sudo mv cfssljson_linux-amd64 /usr/local/bin/cfssljson
 
 Verify `cfssl` version 1.2.0 or higher is installed:
 
-```
+```sh
 cfssl version
 ```
 
 > output
 
 ```
-Version: 1.2.0
+Version: 1.3.4
 Revision: dev
-Runtime: go1.6
+Runtime: go1.12.7
 ```
 
 > The cfssljson command line utility does not provide a way to print its version.
 
 ## Install kubectl
 
-The `kubectl` command line utility is used to interact with the Kubernetes API Server. Download and install `kubectl` from the official release binaries:
+The `kubectl` command line utility is used to interact with the Kubernetes API Server.
+Download and install latest stable `kubectl` from the official release binaries:
 
 ### OS X
 
-```
-curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/darwin/amd64/kubectl
+```sh
+curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl"
 ```
 
-```
+```sh
 chmod +x kubectl
 ```
 
-```
+```sh
 sudo mv kubectl /usr/local/bin/
 ```
 
 ### Linux
 
-```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl
+```sh
+curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
 ```
 
-```
+```sh
 chmod +x kubectl
 ```
 
-```
+```sh
 sudo mv kubectl /usr/local/bin/
 ```
 
 ### Verification
 
-Verify `kubectl` version 1.12.0 or higher is installed:
+Verify `kubectl` version 1.14.0 or higher is installed:
 
-```
+```sh
 kubectl version --client
 ```
 
 > output
 
 ```
-Client Version: version.Info{Major:"1", Minor:"12", GitVersion:"v1.12.0", GitCommit:"0ed33881dc4355495f623c6f22e7dd0b7632b7c0", GitTreeState:"clean", BuildDate:"2018-09-27T17:05:32Z", GoVersion:"go1.10.4", Compiler:"gc", Platform:"linux/amd64"}
+Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.1", GitCommit:"4485c6f18cee9a5d3c3b4e523bd27972b1b53892", GitTreeState:"clean", BuildDate:"2019-07-18T09:18:22Z", GoVersion:"go1.12.5", Compiler:"gc", Platform:"darwin/amd64"}
 ```
 
 Next: [Provisioning Compute Resources](03-compute-resources.md)

--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -16,7 +16,7 @@ In this section a dedicated [Virtual Private Cloud](https://cloud.google.com/com
 
 Create the `kubernetes-the-hard-way` custom VPC network:
 
-```
+```sh
 gcloud compute networks create kubernetes-the-hard-way --subnet-mode custom
 ```
 
@@ -24,7 +24,7 @@ A [subnet](https://cloud.google.com/compute/docs/vpc/#vpc_networks_and_subnets) 
 
 Create the `kubernetes` subnet in the `kubernetes-the-hard-way` VPC network:
 
-```
+```sh
 gcloud compute networks subnets create kubernetes \
   --network kubernetes-the-hard-way \
   --range 10.240.0.0/24
@@ -36,7 +36,7 @@ gcloud compute networks subnets create kubernetes \
 
 Create a firewall rule that allows internal communication across all protocols:
 
-```
+```sh
 gcloud compute firewall-rules create kubernetes-the-hard-way-allow-internal \
   --allow tcp,udp,icmp \
   --network kubernetes-the-hard-way \
@@ -45,7 +45,7 @@ gcloud compute firewall-rules create kubernetes-the-hard-way-allow-internal \
 
 Create a firewall rule that allows external SSH, ICMP, and HTTPS:
 
-```
+```sh
 gcloud compute firewall-rules create kubernetes-the-hard-way-allow-external \
   --allow tcp:22,tcp:6443,icmp \
   --network kubernetes-the-hard-way \
@@ -56,7 +56,7 @@ gcloud compute firewall-rules create kubernetes-the-hard-way-allow-external \
 
 List the firewall rules in the `kubernetes-the-hard-way` VPC network:
 
-```
+```sh
 gcloud compute firewall-rules list --filter="network:kubernetes-the-hard-way"
 ```
 
@@ -72,14 +72,14 @@ kubernetes-the-hard-way-allow-internal  kubernetes-the-hard-way  INGRESS    1000
 
 Allocate a static IP address that will be attached to the external load balancer fronting the Kubernetes API Servers:
 
-```
+```sh
 gcloud compute addresses create kubernetes-the-hard-way \
   --region $(gcloud config get-value compute/region)
 ```
 
 Verify the `kubernetes-the-hard-way` static IP address was created in your default compute region:
 
-```
+```sh
 gcloud compute addresses list --filter="name=('kubernetes-the-hard-way')"
 ```
 
@@ -98,7 +98,7 @@ The compute instances in this lab will be provisioned using [Ubuntu Server](http
 
 Create three compute instances which will host the Kubernetes control plane:
 
-```
+```sh
 for i in 0 1 2; do
   gcloud compute instances create controller-${i} \
     --async \
@@ -122,7 +122,7 @@ Each worker instance requires a pod subnet allocation from the Kubernetes cluste
 
 Create three compute instances which will host the Kubernetes worker nodes:
 
-```
+```sh
 for i in 0 1 2; do
   gcloud compute instances create worker-${i} \
     --async \
@@ -143,7 +143,7 @@ done
 
 List the compute instances in your default compute zone:
 
-```
+```sh
 gcloud compute instances list
 ```
 
@@ -165,7 +165,7 @@ SSH will be used to configure the controller and worker instances. When connecti
 
 Test SSH access to the `controller-0` compute instances:
 
-```
+```sh
 gcloud compute ssh controller-0
 ```
 
@@ -217,12 +217,12 @@ Last login: Sun May 13 14:34:27 2018 from XX.XXX.XXX.XX
 
 Type `exit` at the prompt to exit the `controller-0` compute instance:
 
-```
+```sh
 $USER@controller-0:~$ exit
 ```
 > output
 
-```
+```sh
 logout
 Connection to XX.XXX.XXX.XXX closed
 ```

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -8,7 +8,7 @@ In this section you will provision a Certificate Authority that can be used to g
 
 Generate the CA configuration file, certificate, and private key:
 
-```
+```sh
 {
 
 cat > ca-config.json <<EOF
@@ -54,7 +54,11 @@ cfssl gencert -initca ca-csr.json | cfssljson -bare ca
 Results:
 
 ```
+$ ls -p | grep -v /
+ca-config.json
+ca-csr.json
 ca-key.pem
+ca.csr
 ca.pem
 ```
 
@@ -66,7 +70,7 @@ In this section you will generate client and server certificates for each Kubern
 
 Generate the `admin` client certificate and private key:
 
-```
+```sh
 {
 
 cat > admin-csr.json <<EOF
@@ -101,19 +105,21 @@ cfssl gencert \
 Results:
 
 ```
+admin-csr.json
 admin-key.pem
+admin.csr
 admin.pem
 ```
 
 ### The Kubelet Client Certificates
 
-Kubernetes uses a [special-purpose authorization mode](https://kubernetes.io/docs/admin/authorization/node/) called Node Authorizer, that specifically authorizes API requests made by [Kubelets](https://kubernetes.io/docs/concepts/overview/components/#kubelet). In order to be authorized by the Node Authorizer, Kubelets must use a credential that identifies them as being in the `system:nodes` group, with a username of `system:node:<nodeName>`. In this section you will create a certificate for each Kubernetes worker node that meets the Node Authorizer requirements.
+Kubernetes uses a **special-purpose authorization mode** called [Node Authorizer](https://kubernetes.io/docs/admin/authorization/node/), that specifically authorizes API requests made by [Kubelets](https://kubernetes.io/docs/concepts/overview/components/#kubelet). In order to be authorized by the Node Authorizer, Kubelets must use a credential that identifies them as being in the `system:nodes` group, with a username of `system:node:<nodeName>`. In this section you will create a certificate for each Kubernetes worker node that meets the Node Authorizer requirements.
 
 Generate a certificate and private key for each Kubernetes worker node:
 
-```
+```sh
 for instance in worker-0 worker-1 worker-2; do
-cat > ${instance}-csr.json <<EOF
+  cat > ${instance}-csr.json <<EOF
 {
   "CN": "system:node:${instance}",
   "key": {
@@ -132,30 +138,36 @@ cat > ${instance}-csr.json <<EOF
 }
 EOF
 
-EXTERNAL_IP=$(gcloud compute instances describe ${instance} \
-  --format 'value(networkInterfaces[0].accessConfigs[0].natIP)')
+  EXTERNAL_IP=$(gcloud compute instances describe ${instance} \
+    --format 'value(networkInterfaces[0].accessConfigs[0].natIP)')
 
-INTERNAL_IP=$(gcloud compute instances describe ${instance} \
-  --format 'value(networkInterfaces[0].networkIP)')
+  INTERNAL_IP=$(gcloud compute instances describe ${instance} \
+    --format 'value(networkInterfaces[0].networkIP)')
 
-cfssl gencert \
-  -ca=ca.pem \
-  -ca-key=ca-key.pem \
-  -config=ca-config.json \
-  -hostname=${instance},${EXTERNAL_IP},${INTERNAL_IP} \
-  -profile=kubernetes \
-  ${instance}-csr.json | cfssljson -bare ${instance}
+  cfssl gencert \
+    -ca=ca.pem \
+    -ca-key=ca-key.pem \
+    -config=ca-config.json \
+    -hostname=${instance},${EXTERNAL_IP},${INTERNAL_IP} \
+    -profile=kubernetes \
+    ${instance}-csr.json | cfssljson -bare ${instance}
 done
 ```
 
 Results:
 
 ```
+worker-0-csr.json
 worker-0-key.pem
+worker-0.csr
 worker-0.pem
+worker-1-csr.json
 worker-1-key.pem
+worker-1.csr
 worker-1.pem
+worker-2-csr.json
 worker-2-key.pem
+worker-2.csr
 worker-2.pem
 ```
 
@@ -163,10 +175,10 @@ worker-2.pem
 
 Generate the `kube-controller-manager` client certificate and private key:
 
-```
+```sh
 {
 
-cat > kube-controller-manager-csr.json <<EOF
+  cat > kube-controller-manager-csr.json <<EOF
 {
   "CN": "system:kube-controller-manager",
   "key": {
@@ -185,12 +197,12 @@ cat > kube-controller-manager-csr.json <<EOF
 }
 EOF
 
-cfssl gencert \
-  -ca=ca.pem \
-  -ca-key=ca-key.pem \
-  -config=ca-config.json \
-  -profile=kubernetes \
-  kube-controller-manager-csr.json | cfssljson -bare kube-controller-manager
+  cfssl gencert \
+    -ca=ca.pem \
+    -ca-key=ca-key.pem \
+    -config=ca-config.json \
+    -profile=kubernetes \
+    kube-controller-manager-csr.json | cfssljson -bare kube-controller-manager
 
 }
 ```
@@ -198,7 +210,9 @@ cfssl gencert \
 Results:
 
 ```
+kube-controller-manager-csr.json
 kube-controller-manager-key.pem
+kube-controller-manager.csr
 kube-controller-manager.pem
 ```
 
@@ -207,10 +221,9 @@ kube-controller-manager.pem
 
 Generate the `kube-proxy` client certificate and private key:
 
-```
+```sh
 {
-
-cat > kube-proxy-csr.json <<EOF
+  cat > kube-proxy-csr.json <<EOF
 {
   "CN": "system:kube-proxy",
   "key": {
@@ -229,12 +242,12 @@ cat > kube-proxy-csr.json <<EOF
 }
 EOF
 
-cfssl gencert \
-  -ca=ca.pem \
-  -ca-key=ca-key.pem \
-  -config=ca-config.json \
-  -profile=kubernetes \
-  kube-proxy-csr.json | cfssljson -bare kube-proxy
+  cfssl gencert \
+    -ca=ca.pem \
+    -ca-key=ca-key.pem \
+    -config=ca-config.json \
+    -profile=kubernetes \
+    kube-proxy-csr.json | cfssljson -bare kube-proxy
 
 }
 ```
@@ -242,7 +255,9 @@ cfssl gencert \
 Results:
 
 ```
+kube-proxy-csr.json
 kube-proxy-key.pem
+kube-proxy.csr
 kube-proxy.pem
 ```
 
@@ -250,10 +265,10 @@ kube-proxy.pem
 
 Generate the `kube-scheduler` client certificate and private key:
 
-```
+```sh
 {
 
-cat > kube-scheduler-csr.json <<EOF
+  cat > kube-scheduler-csr.json <<EOF
 {
   "CN": "system:kube-scheduler",
   "key": {
@@ -272,12 +287,12 @@ cat > kube-scheduler-csr.json <<EOF
 }
 EOF
 
-cfssl gencert \
-  -ca=ca.pem \
-  -ca-key=ca-key.pem \
-  -config=ca-config.json \
-  -profile=kubernetes \
-  kube-scheduler-csr.json | cfssljson -bare kube-scheduler
+  cfssl gencert \
+    -ca=ca.pem \
+    -ca-key=ca-key.pem \
+    -config=ca-config.json \
+    -profile=kubernetes \
+    kube-scheduler-csr.json | cfssljson -bare kube-scheduler
 
 }
 ```
@@ -285,7 +300,9 @@ cfssl gencert \
 Results:
 
 ```
+kube-scheduler-csr.json
 kube-scheduler-key.pem
+kube-scheduler.csr
 kube-scheduler.pem
 ```
 
@@ -296,14 +313,14 @@ The `kubernetes-the-hard-way` static IP address will be included in the list of 
 
 Generate the Kubernetes API Server certificate and private key:
 
-```
+```sh
 {
 
-KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
-  --region $(gcloud config get-value compute/region) \
-  --format 'value(address)')
+  KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
+    --region $(gcloud config get-value compute/region) \
+    --format 'value(address)')
 
-cat > kubernetes-csr.json <<EOF
+  cat > kubernetes-csr.json <<EOF
 {
   "CN": "kubernetes",
   "key": {
@@ -322,13 +339,13 @@ cat > kubernetes-csr.json <<EOF
 }
 EOF
 
-cfssl gencert \
-  -ca=ca.pem \
-  -ca-key=ca-key.pem \
-  -config=ca-config.json \
-  -hostname=10.32.0.1,10.240.0.10,10.240.0.11,10.240.0.12,${KUBERNETES_PUBLIC_ADDRESS},127.0.0.1,kubernetes.default \
-  -profile=kubernetes \
-  kubernetes-csr.json | cfssljson -bare kubernetes
+  cfssl gencert \
+    -ca=ca.pem \
+    -ca-key=ca-key.pem \
+    -config=ca-config.json \
+    -hostname=10.32.0.1,10.240.0.10,10.240.0.11,10.240.0.12,${KUBERNETES_PUBLIC_ADDRESS},127.0.0.1,kubernetes.default \
+    -profile=kubernetes \
+    kubernetes-csr.json | cfssljson -bare kubernetes
 
 }
 ```
@@ -336,7 +353,9 @@ cfssl gencert \
 Results:
 
 ```
+kubernetes-csr.json
 kubernetes-key.pem
+kubernetes.csr
 kubernetes.pem
 ```
 
@@ -346,10 +365,10 @@ The Kubernetes Controller Manager leverages a key pair to generate and sign serv
 
 Generate the `service-account` certificate and private key:
 
-```
+```sh
 {
 
-cat > service-account-csr.json <<EOF
+  cat > service-account-csr.json <<EOF
 {
   "CN": "service-accounts",
   "key": {
@@ -368,12 +387,12 @@ cat > service-account-csr.json <<EOF
 }
 EOF
 
-cfssl gencert \
-  -ca=ca.pem \
-  -ca-key=ca-key.pem \
-  -config=ca-config.json \
-  -profile=kubernetes \
-  service-account-csr.json | cfssljson -bare service-account
+  cfssl gencert \
+    -ca=ca.pem \
+    -ca-key=ca-key.pem \
+    -config=ca-config.json \
+    -profile=kubernetes \
+    service-account-csr.json | cfssljson -bare service-account
 
 }
 ```
@@ -381,24 +400,30 @@ cfssl gencert \
 Results:
 
 ```
+service-account-csr.json
 service-account-key.pem
+service-account.csr
 service-account.pem
 ```
-
 
 ## Distribute the Client and Server Certificates
 
 Copy the appropriate certificates and private keys to each worker instance:
+- ca.pem
+- worker-X.pem & worker-X-key.pem
 
-```
+```sh
 for instance in worker-0 worker-1 worker-2; do
   gcloud compute scp ca.pem ${instance}-key.pem ${instance}.pem ${instance}:~/
 done
 ```
 
 Copy the appropriate certificates and private keys to each controller instance:
+- ca.pem & ca-key.pem
+- kubernetes-key.pem & kubernetes.pem
+- service-account-key.pem & service-account.pem
 
-```
+```sh
 for instance in controller-0 controller-1 controller-2; do
   gcloud compute scp ca.pem ca-key.pem kubernetes-key.pem kubernetes.pem \
     service-account-key.pem service-account.pem ${instance}:~/

--- a/docs/05-kubernetes-configuration-files.md
+++ b/docs/05-kubernetes-configuration-files.md
@@ -1,6 +1,6 @@
 # Generating Kubernetes Configuration Files for Authentication
 
-In this lab you will generate [Kubernetes configuration files](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/), also known as kubeconfigs, which enable Kubernetes clients to locate and authenticate to the Kubernetes API Servers.
+In this lab you will generate [Kubernetes configuration files](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/), also known as `kubeconfig`s, which enable Kubernetes clients to locate and authenticate to the Kubernetes API Servers.
 
 ## Client Authentication Configs
 
@@ -12,7 +12,7 @@ Each kubeconfig requires a Kubernetes API Server to connect to. To support high 
 
 Retrieve the `kubernetes-the-hard-way` static IP address:
 
-```
+```sh
 KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
   --region $(gcloud config get-value compute/region) \
   --format 'value(address)')
@@ -24,7 +24,7 @@ When generating kubeconfig files for Kubelets the client certificate matching th
 
 Generate a kubeconfig file for each worker node:
 
-```
+```sh
 for instance in worker-0 worker-1 worker-2; do
   kubectl config set-cluster kubernetes-the-hard-way \
     --certificate-authority=ca.pem \
@@ -59,8 +59,9 @@ worker-2.kubeconfig
 
 Generate a kubeconfig file for the `kube-proxy` service:
 
-```
+```sh
 {
+
   kubectl config set-cluster kubernetes-the-hard-way \
     --certificate-authority=ca.pem \
     --embed-certs=true \
@@ -79,6 +80,7 @@ Generate a kubeconfig file for the `kube-proxy` service:
     --kubeconfig=kube-proxy.kubeconfig
 
   kubectl config use-context default --kubeconfig=kube-proxy.kubeconfig
+
 }
 ```
 
@@ -92,8 +94,9 @@ kube-proxy.kubeconfig
 
 Generate a kubeconfig file for the `kube-controller-manager` service:
 
-```
+```sh
 {
+
   kubectl config set-cluster kubernetes-the-hard-way \
     --certificate-authority=ca.pem \
     --embed-certs=true \
@@ -112,6 +115,7 @@ Generate a kubeconfig file for the `kube-controller-manager` service:
     --kubeconfig=kube-controller-manager.kubeconfig
 
   kubectl config use-context default --kubeconfig=kube-controller-manager.kubeconfig
+
 }
 ```
 
@@ -126,8 +130,9 @@ kube-controller-manager.kubeconfig
 
 Generate a kubeconfig file for the `kube-scheduler` service:
 
-```
+```sh
 {
+
   kubectl config set-cluster kubernetes-the-hard-way \
     --certificate-authority=ca.pem \
     --embed-certs=true \
@@ -146,6 +151,7 @@ Generate a kubeconfig file for the `kube-scheduler` service:
     --kubeconfig=kube-scheduler.kubeconfig
 
   kubectl config use-context default --kubeconfig=kube-scheduler.kubeconfig
+
 }
 ```
 
@@ -159,8 +165,9 @@ kube-scheduler.kubeconfig
 
 Generate a kubeconfig file for the `admin` user:
 
-```
+```sh
 {
+
   kubectl config set-cluster kubernetes-the-hard-way \
     --certificate-authority=ca.pem \
     --embed-certs=true \
@@ -179,6 +186,7 @@ Generate a kubeconfig file for the `admin` user:
     --kubeconfig=admin.kubeconfig
 
   kubectl config use-context default --kubeconfig=admin.kubeconfig
+
 }
 ```
 
@@ -188,14 +196,11 @@ Results:
 admin.kubeconfig
 ```
 
-
-## 
-
 ## Distribute the Kubernetes Configuration Files
 
 Copy the appropriate `kubelet` and `kube-proxy` kubeconfig files to each worker instance:
 
-```
+```sh
 for instance in worker-0 worker-1 worker-2; do
   gcloud compute scp ${instance}.kubeconfig kube-proxy.kubeconfig ${instance}:~/
 done
@@ -203,7 +208,7 @@ done
 
 Copy the appropriate `kube-controller-manager` and `kube-scheduler` kubeconfig files to each controller instance:
 
-```
+```sh
 for instance in controller-0 controller-1 controller-2; do
   gcloud compute scp admin.kubeconfig kube-controller-manager.kubeconfig kube-scheduler.kubeconfig ${instance}:~/
 done

--- a/docs/06-data-encryption-keys.md
+++ b/docs/06-data-encryption-keys.md
@@ -16,7 +16,7 @@ ENCRYPTION_KEY=$(head -c 32 /dev/urandom | base64)
 
 Create the `encryption-config.yaml` encryption config file:
 
-```
+```sh
 cat > encryption-config.yaml <<EOF
 kind: EncryptionConfig
 apiVersion: v1
@@ -34,7 +34,7 @@ EOF
 
 Copy the `encryption-config.yaml` encryption config file to each controller instance:
 
-```
+```sh
 for instance in controller-0 controller-1 controller-2; do
   gcloud compute scp encryption-config.yaml ${instance}:~/
 done

--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -6,7 +6,7 @@ Kubernetes components are stateless and store cluster state in [etcd](https://gi
 
 The commands in this lab must be run on each controller instance: `controller-0`, `controller-1`, and `controller-2`. Login to each controller instance using the `gcloud` command. Example:
 
-```
+```sh
 gcloud compute ssh controller-0
 ```
 
@@ -20,45 +20,41 @@ gcloud compute ssh controller-0
 
 Download the official etcd release binaries from the [coreos/etcd](https://github.com/coreos/etcd) GitHub project:
 
-```
+```sh
 wget -q --show-progress --https-only --timestamping \
-  "https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz"
+  "https://github.com/etcd-io/etcd/releases/download/v3.3.13/etcd-v3.3.13-linux-amd64.tar.gz"
 ```
 
 Extract and install the `etcd` server and the `etcdctl` command line utility:
 
-```
-{
-  tar -xvf etcd-v3.3.9-linux-amd64.tar.gz
-  sudo mv etcd-v3.3.9-linux-amd64/etcd* /usr/local/bin/
-}
+```sh
+tar -xvf etcd-v3.3.13-linux-amd64.tar.gz
+sudo mv etcd-v3.3.13-linux-amd64/etcd* /usr/local/bin/
 ```
 
 ### Configure the etcd Server
 
-```
-{
-  sudo mkdir -p /etc/etcd /var/lib/etcd
-  sudo cp ca.pem kubernetes-key.pem kubernetes.pem /etc/etcd/
-}
+```sh
+sudo mkdir -p /etc/etcd /var/lib/etcd
+sudo cp ca.pem kubernetes-key.pem kubernetes.pem /etc/etcd/
 ```
 
 The instance internal IP address will be used to serve client requests and communicate with etcd cluster peers. Retrieve the internal IP address for the current compute instance:
 
-```
+```sh
 INTERNAL_IP=$(curl -s -H "Metadata-Flavor: Google" \
   http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip)
 ```
 
 Each etcd member must have a unique name within an etcd cluster. Set the etcd name to match the hostname of the current compute instance:
 
-```
+```sh
 ETCD_NAME=$(hostname -s)
 ```
 
 Create the `etcd.service` systemd unit file:
 
-```
+```sh
 cat <<EOF | sudo tee /etc/systemd/system/etcd.service
 [Unit]
 Description=etcd
@@ -93,7 +89,7 @@ EOF
 
 ### Start the etcd Server
 
-```
+```sh
 {
   sudo systemctl daemon-reload
   sudo systemctl enable etcd
@@ -107,7 +103,7 @@ EOF
 
 List the etcd cluster members:
 
-```
+```sh
 sudo ETCDCTL_API=3 etcdctl member list \
   --endpoints=https://127.0.0.1:2379 \
   --cacert=/etc/etcd/ca.pem \

--- a/docs/10-configuring-kubectl.md
+++ b/docs/10-configuring-kubectl.md
@@ -10,7 +10,7 @@ Each kubeconfig requires a Kubernetes API Server to connect to. To support high 
 
 Generate a kubeconfig file suitable for authenticating as the `admin` user:
 
-```
+```sh
 {
   KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
     --region $(gcloud config get-value compute/region) \
@@ -37,7 +37,7 @@ Generate a kubeconfig file suitable for authenticating as the `admin` user:
 
 Check the health of the remote Kubernetes cluster:
 
-```
+```sh
 kubectl get componentstatuses
 ```
 
@@ -54,17 +54,17 @@ etcd-0               Healthy   {"health":"true"}
 
 List the nodes in the remote Kubernetes cluster:
 
-```
+```sh
 kubectl get nodes
 ```
 
 > output
 
 ```
-NAME       STATUS   ROLES    AGE    VERSION
-worker-0   Ready    <none>   117s   v1.12.0
-worker-1   Ready    <none>   118s   v1.12.0
-worker-2   Ready    <none>   118s   v1.12.0
+NAME       STATUS   ROLES    AGE     VERSION
+worker-0   Ready    <none>   3m59s   v1.14.4
+worker-1   Ready    <none>   3m58s   v1.14.4
+worker-2   Ready    <none>   3m57s   v1.14.4
 ```
 
 Next: [Provisioning Pod Network Routes](11-pod-network-routes.md)

--- a/docs/11-pod-network-routes.md
+++ b/docs/11-pod-network-routes.md
@@ -12,7 +12,7 @@ In this section you will gather the information required to create routes in the
 
 Print the internal IP address and Pod CIDR range for each worker instance:
 
-```
+```sh
 for instance in worker-0 worker-1 worker-2; do
   gcloud compute instances describe ${instance} \
     --format 'value[separator=" "](networkInterfaces[0].networkIP,metadata.items[0].value)'
@@ -31,7 +31,7 @@ done
 
 Create network routes for each worker instance:
 
-```
+```sh
 for i in 0 1 2; do
   gcloud compute routes create kubernetes-route-10-200-${i}-0-24 \
     --network kubernetes-the-hard-way \
@@ -42,7 +42,7 @@ done
 
 List the routes in the `kubernetes-the-hard-way` VPC network:
 
-```
+```sh
 gcloud compute routes list --filter "network: kubernetes-the-hard-way"
 ```
 

--- a/docs/12-dns-addon.md
+++ b/docs/12-dns-addon.md
@@ -6,7 +6,7 @@ In this lab you will deploy the [DNS add-on](https://kubernetes.io/docs/concepts
 
 Deploy the `coredns` cluster add-on:
 
-```
+```sh
 kubectl apply -f https://storage.googleapis.com/kubernetes-the-hard-way/coredns.yaml
 ```
 
@@ -23,7 +23,7 @@ service/kube-dns created
 
 List the pods created by the `kube-dns` deployment:
 
-```
+```sh
 kubectl get pods -l k8s-app=kube-dns -n kube-system
 ```
 
@@ -39,13 +39,13 @@ coredns-699f8ddd77-gtcgb   1/1     Running   0          20s
 
 Create a `busybox` deployment:
 
-```
+```sh
 kubectl run busybox --image=busybox:1.28 --command -- sleep 3600
 ```
 
 List the pod created by the `busybox` deployment:
 
-```
+```sh
 kubectl get pods -l run=busybox
 ```
 
@@ -64,7 +64,7 @@ POD_NAME=$(kubectl get pods -l run=busybox -o jsonpath="{.items[0].metadata.name
 
 Execute a DNS lookup for the `kubernetes` service inside the `busybox` pod:
 
-```
+```sh
 kubectl exec -ti $POD_NAME -- nslookup kubernetes
 ```
 

--- a/docs/14-cleanup.md
+++ b/docs/14-cleanup.md
@@ -6,7 +6,7 @@ In this lab you will delete the compute resources created during this tutorial.
 
 Delete the controller and worker compute instances:
 
-```
+```sh
 gcloud -q compute instances delete \
   controller-0 controller-1 controller-2 \
   worker-0 worker-1 worker-2
@@ -16,7 +16,7 @@ gcloud -q compute instances delete \
 
 Delete the external load balancer network resources:
 
-```
+```sh
 {
   gcloud -q compute forwarding-rules delete kubernetes-forwarding-rule \
     --region $(gcloud config get-value compute/region)
@@ -31,7 +31,7 @@ Delete the external load balancer network resources:
 
 Delete the `kubernetes-the-hard-way` firewall rules:
 
-```
+```sh
 gcloud -q compute firewall-rules delete \
   kubernetes-the-hard-way-allow-nginx-service \
   kubernetes-the-hard-way-allow-internal \


### PR DESCRIPTION
Update to Kubernetes v1.14.4 with necessary fixes.
Please don't forget, the current CKA, as of now, is on Kubernetes v1.14!