### PR TITLE
Do not overwrite /bin by destroying symlink

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -63,7 +63,9 @@ Install the worker binaries:
   sudo mv kubectl kube-proxy kubelet runc runsc /usr/local/bin/
   sudo tar -xvf crictl-v1.12.0-linux-amd64.tar.gz -C /usr/local/bin/
   sudo tar -xvf cni-plugins-amd64-v0.6.0.tgz -C /opt/cni/bin/
-  sudo tar -xvf containerd-1.2.0-rc.0.linux-amd64.tar.gz -C /
+  mkdir ./containerd
+  tar -xvf containerd-1.2.0-rc.0.linux-amd64.tar.gz -C ./containerd
+  sudo mv ./containerd/bin/* /bin/
 }
 ```
 


### PR DESCRIPTION
As per #434 when /bin/ is a symlink to another path (e.g. /usr/bin/) using `tar -C /` will overwrite the symlink and tank the whole system.

Un-tar containerd binaries into the user's home folder and then `sudo mv` them into the correct location