### PR TITLE
Fixed typo of kube-controller-manager

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -113,7 +113,7 @@ EOF
 Move the `kube-controller-manager` kubeconfig into place:
 
 ```
-sudo mv kube-controller-manager.kubeconfig /var/lib/kubernetes/
+sudo mv kube-controller-manager /var/lib/kubernetes/
 ```
 
 Create the `kube-controller-manager.service` systemd unit file:


### PR DESCRIPTION
Removed .kubeconfig from the end of kube-controller-manager.