### PR TITLE
Fix hostname typo

### DIFF
--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -303,7 +303,7 @@ KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-har
   --region $(gcloud config get-value compute/region) \
   --format 'value(address)')
 
-KUBERNETES_HOSTNAMES=kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.svc.cluster.local
+KUBERNETES_HOSTNAMES=kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local
 
 cat > kubernetes-csr.json <<EOF
 {


### PR DESCRIPTION
Missing `default` in `kubernetes.default.svc.cluster.local` hostname