### PR TITLE
Make the nodes private, add Cloud NAT, IAP for SSH and Expose the nginx behind a TCP LB

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -46,9 +46,9 @@ Create a Google Cloud NAT Gateway
 
 ```
 gcloud compute routers nats create kube-nat-gateway \
-    --router=kube-nat-router \
-    --auto-allocate-nat-external-ips \
-    --nat-all-subnet-ip-ranges
+  --router=kube-nat-router \
+  --auto-allocate-nat-external-ips \
+  --nat-all-subnet-ip-ranges
 ```
 
 ### Firewall Rules

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -132,9 +132,6 @@ cat > ${instance}-csr.json <<EOF
 }
 EOF
 
-EXTERNAL_IP=$(gcloud compute instances describe ${instance} \
-  --format 'value(networkInterfaces[0].accessConfigs[0].natIP)')
-
 INTERNAL_IP=$(gcloud compute instances describe ${instance} \
   --format 'value(networkInterfaces[0].networkIP)')
 
@@ -142,7 +139,7 @@ cfssl gencert \
   -ca=ca.pem \
   -ca-key=ca-key.pem \
   -config=ca-config.json \
-  -hostname=${instance},${EXTERNAL_IP},${INTERNAL_IP} \
+  -hostname=${instance},${INTERNAL_IP} \
   -profile=kubernetes \
   ${instance}-csr.json | cfssljson -bare ${instance}
 done
@@ -396,7 +393,7 @@ Copy the appropriate certificates and private keys to each worker instance:
 
 ```
 for instance in worker-0 worker-1 worker-2; do
-  gcloud compute scp ca.pem ${instance}-key.pem ${instance}.pem ${instance}:~/
+  gcloud compute scp --tunnel-through-iap ca.pem ${instance}-key.pem ${instance}.pem ${instance}:~/
 done
 ```
 
@@ -404,7 +401,7 @@ Copy the appropriate certificates and private keys to each controller instance:
 
 ```
 for instance in controller-0 controller-1 controller-2; do
-  gcloud compute scp ca.pem ca-key.pem kubernetes-key.pem kubernetes.pem \
+  gcloud compute scp --tunnel-through-iap ca.pem ca-key.pem kubernetes-key.pem kubernetes.pem \
     service-account-key.pem service-account.pem ${instance}:~/
 done
 ```

--- a/docs/05-kubernetes-configuration-files.md
+++ b/docs/05-kubernetes-configuration-files.md
@@ -199,7 +199,7 @@ Copy the appropriate `kubelet` and `kube-proxy` kubeconfig files to each worker 
 
 ```
 for instance in worker-0 worker-1 worker-2; do
-  gcloud compute scp ${instance}.kubeconfig kube-proxy.kubeconfig ${instance}:~/
+  gcloud compute scp --tunnel-through-iap ${instance}.kubeconfig kube-proxy.kubeconfig ${instance}:~/ 
 done
 ```
 
@@ -207,7 +207,7 @@ Copy the appropriate `kube-controller-manager` and `kube-scheduler` kubeconfig f
 
 ```
 for instance in controller-0 controller-1 controller-2; do
-  gcloud compute scp admin.kubeconfig kube-controller-manager.kubeconfig kube-scheduler.kubeconfig ${instance}:~/
+  gcloud compute scp --tunnel-through-iap admin.kubeconfig  kube-controller-manager.kubeconfig kube-scheduler.kubeconfig  ${instance}:~/
 done
 ```
 

--- a/docs/06-data-encryption-keys.md
+++ b/docs/06-data-encryption-keys.md
@@ -36,7 +36,7 @@ Copy the `encryption-config.yaml` encryption config file to each controller inst
 
 ```
 for instance in controller-0 controller-1 controller-2; do
-  gcloud compute scp encryption-config.yaml ${instance}:~/
+  gcloud compute scp --tunnel-through-iap encryption-config.yaml ${instance}:~/
 done
 ```
 

--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -7,7 +7,7 @@ Kubernetes components are stateless and store cluster state in [etcd](https://gi
 The commands in this lab must be run on each controller instance: `controller-0`, `controller-1`, and `controller-2`. Login to each controller instance using the `gcloud` command. Example:
 
 ```
-gcloud compute ssh controller-0
+gcloud compute ssh --tunnel-through-iap controller-0
 ```
 
 ### Running commands in parallel with tmux

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -7,7 +7,7 @@ In this lab you will bootstrap the Kubernetes control plane across three compute
 The commands in this lab must be run on each controller instance: `controller-0`, `controller-1`, and `controller-2`. Login to each controller instance using the `gcloud` command. Example:
 
 ```
-gcloud compute ssh controller-0
+gcloud compute ssh --tunnel-through-iap controller-0
 ```
 
 ### Running commands in parallel with tmux
@@ -272,8 +272,6 @@ Content-Type: text/plain; charset=utf-8
 Content-Length: 2
 Connection: keep-alive
 X-Content-Type-Options: nosniff
-
-ok
 ```
 
 > Remember to run the above commands on each controller node: `controller-0`, `controller-1`, and `controller-2`.
@@ -287,7 +285,7 @@ In this section you will configure RBAC permissions to allow the Kubernetes API 
 The commands in this section will effect the entire cluster and only need to be run once from one of the controller nodes.
 
 ```
-gcloud compute ssh controller-0
+gcloud compute ssh --tunnel-through-iap controller-0
 ```
 
 Create the `system:kube-apiserver-to-kubelet` [ClusterRole](https://kubernetes.io/docs/admin/authorization/rbac/#role-and-clusterrole) with permissions to access the Kubelet API and perform most common tasks associated with managing pods:

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -284,7 +284,7 @@ EOF
 {
   sudo systemctl daemon-reload
   sudo systemctl enable containerd kubelet kube-proxy
-  sudo systemctl status containerd kubelet kube-proxy
+  sudo systemctl start containerd kubelet kube-proxy
 }
 ```
 

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -7,7 +7,7 @@ In this lab you will bootstrap three Kubernetes worker nodes. The following comp
 The commands in this lab must be run on each worker instance: `worker-0`, `worker-1`, and `worker-2`. Login to each worker instance using the `gcloud` command. Example:
 
 ```
-gcloud compute ssh worker-0
+gcloud compute ssh --tunnel-through-iap worker-0
 ```
 
 ### Running commands in parallel with tmux
@@ -284,7 +284,7 @@ EOF
 {
   sudo systemctl daemon-reload
   sudo systemctl enable containerd kubelet kube-proxy
-  sudo systemctl start containerd kubelet kube-proxy
+  sudo systemctl status containerd kubelet kube-proxy
 }
 ```
 
@@ -297,7 +297,7 @@ EOF
 List the registered Kubernetes nodes:
 
 ```
-gcloud compute ssh controller-0 \
+gcloud compute ssh --tunnel-through-iap controller-0 \
   --command "kubectl get nodes --kubeconfig admin.kubeconfig"
 ```
 

--- a/docs/14-cleanup.md
+++ b/docs/14-cleanup.md
@@ -16,7 +16,6 @@ gcloud -q compute instances delete \
 ## Networking
 
 Delete the external load balancer network resources:
-
 ```
 {
   gcloud -q compute forwarding-rules delete kubernetes-forwarding-rule \
@@ -30,11 +29,27 @@ Delete the external load balancer network resources:
 }
 ```
 
+Delete the Nginx service external load balancer network resources:
+```
+{
+  gcloud -q compute forwarding-rules delete nginx-service \
+    --region $(gcloud config get-value compute/region)
+
+  gcloud -q compute target-pools delete nginx-service
+
+  gcloud -q compute http-health-checks delete nginx-service
+
+  gcloud -q compute addresses delete nginx-service
+
+  gcloud -q compute firewall-rules delete nginx-service
+}
+```
+
 Delete the `kubernetes-the-hard-way` firewall rules:
 
 ```
 gcloud -q compute firewall-rules delete \
-  kubernetes-the-hard-way-allow-nginx-service \
+  kubernetes-the-hard-way-allow-iap \
   kubernetes-the-hard-way-allow-internal \
   kubernetes-the-hard-way-allow-external \
   kubernetes-the-hard-way-allow-health-check
@@ -48,7 +63,10 @@ Delete the `kubernetes-the-hard-way` network VPC:
     kubernetes-route-10-200-0-0-24 \
     kubernetes-route-10-200-1-0-24 \
     kubernetes-route-10-200-2-0-24
-
+  
+  gcloud -q compute routers delete kube-nat-router \
+    --region $(gcloud config get-value compute/region)
+  
   gcloud -q compute networks subnets delete kubernetes
 
   gcloud -q compute networks delete kubernetes-the-hard-way


### PR DESCRIPTION
Hi Kelsey,

Sumarry of the changes:

- Create nodes with the --no-address flag to remove Public IP's
- Add Cloud NAT for egress connection
- Use IAP TCP Forwarding to SSH into the nodes
- Expose the sample nginx app behind a Net LB since the nodes doesn't have a public IP anymore.

More context can be found here https://github.com/kelseyhightower/kubernetes-the-hard-way/issues/527