### PR TITLE
Replace jsonpath output with cleaner alternative

### DIFF
--- a/docs/12-dns-addon.md
+++ b/docs/12-dns-addon.md
@@ -59,7 +59,7 @@ busybox   1/1     Running   0          3s
 Retrieve the full name of the `busybox` pod:
 
 ```
-POD_NAME=$(kubectl get pods -l run=busybox -o jsonpath="{.items[0].metadata.name}")
+POD_NAME=$(kubectl get pods -l run=busybox -o name)
 ```
 
 Execute a DNS lookup for the `kubernetes` service inside the `busybox` pod:

--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -77,7 +77,7 @@ In this section you will verify the ability to access applications remotely usin
 Retrieve the full name of the `nginx` pod:
 
 ```
-POD_NAME=$(kubectl get pods -l app=nginx -o jsonpath="{.items[0].metadata.name}")
+POD_NAME=$(kubectl get pods -l app=nginx -o name)
 ```
 
 Forward port `8080` on your local machine to port `80` of the `nginx` pod:
@@ -170,7 +170,7 @@ Retrieve the node port assigned to the `nginx` service:
 
 ```
 NODE_PORT=$(kubectl get svc nginx \
-  --output=jsonpath='{range .spec.ports[0]}{.nodePort}')
+  --no-headers -o custom-columns=:.spec.ports[0].nodePort')
 ```
 
 Create a firewall rule that allows remote access to the `nginx` node port:


### PR DESCRIPTION
Hi Kelsey,

Not sure if there was a specific reason for using jsonpath output?

In this PR, I replaced all usages of `-o jsonpath` with cleaner alternatives.