### PR TITLE
added mkdocs index and a sample index.md to go with it

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+# Kubernetes The Hard Way 
+
+Welcome to the Kubernetes The Hard Way  
+
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,21 @@
+site_name: Kubernetes The Hard Way
+pages:
+  - Home: "index.md"
+  - Prerequisites: 01-prerequisites.md
+  - Installing the Client Tools: 02-client-tools.md
+  - Provisioning Compute Resources: 03-compute-resources.md
+  - Provisioning the CA and Generating TLS Certificates: 04-certificate-authority.md
+  - Generating Kubernetes Configuration Files for Authentication: 05-kubernetes-configuration-files.md
+  - Generating the Data Encryption Config and Key: 06-data-encryption-keys.md
+  - Bootstrapping the etcd Cluster: 07-bootstrapping-etcd.md
+  - Bootstrapping the Kubernetes Control Plane: 08-bootstrapping-kubernetes-controllers.md
+  - Bootstrapping the Kubernetes Worker Nodes: 09-bootstrapping-kubernetes-workers.md
+  - Configuring kubectl for Remote Access: 10-configuring-kubectl.md
+  - Provisioning Pod Network Routes: 11-pod-network-routes.md
+  - Deploying the DNS Cluster Add-on: 12-dns-addon.md
+  - Smoke Test:  13-smoke-test.md
+  - Cleaning Up: 14-cleanup.md
+docs_dir: docs
+theme: readthedocs
+plugins:
+    - search


### PR DESCRIPTION
install mkdocs and run "mkdocs gh-deploy" to get a beautiful docs page like python docs. Sample site with my fork is up at https://schoolofdevops.github.io/kubernetes-the-hard-way/