### PR TITLE
KubeletConfiguration: remove ineffective podCIDR option

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -202,7 +202,6 @@ authorization:
 clusterDomain: "cluster.local"
 clusterDNS:
   - "10.32.0.10"
-podCIDR: "${POD_CIDR}"
 resolvConf: "/run/systemd/resolve/resolv.conf"
 runtimeRequestTimeout: "15m"
 tlsCertFile: "/var/lib/kubelet/${HOSTNAME}.pem"


### PR DESCRIPTION
docs for KubeletConfiguration/podCIDR state:
> The CIDR to use for pod IP addresses, only used in standalone mode.
> In cluster mode, this is obtained from the master.
> [...] It should only set for standalone Kubelets, [...]

source: https://github.com/kubernetes/kubernetes/blob/v1.15.3/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L458