### PR TITLE
syntax highlighting

### DIFF
--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -16,7 +16,7 @@ Follow the Google Cloud SDK [documentation](https://cloud.google.com/sdk/) to in
 
 Verify the Google Cloud SDK version is 262.0.0 or higher:
 
-```
+```sh
 gcloud version
 ```
 
@@ -26,25 +26,25 @@ This tutorial assumes a default compute region and zone have been configured.
 
 If you are using the `gcloud` command-line tool for the first time `init` is the easiest way to do this:
 
-```
+```sh
 gcloud init
 ```
 
 Then be sure to authorize gcloud to access the Cloud Platform with your Google user credentials:
 
-```
+```sh
 gcloud auth login
 ```
 
 Next set a default compute region and compute zone:
 
-```
+```sh
 gcloud config set compute/region us-west1
 ```
 
 Set a default compute zone:
 
-```
+```sh
 gcloud config set compute/zone us-west1-c
 ```
 

--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -11,38 +11,38 @@ Download and install `cfssl` and `cfssljson`:
 
 ### OS X
 
-```
+```sh
 curl -o cfssl https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/darwin/cfssl
 curl -o cfssljson https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/darwin/cfssljson
 ```
 
-```
+```sh
 chmod +x cfssl cfssljson
 ```
 
-```
+```sh
 sudo mv cfssl cfssljson /usr/local/bin/
 ```
 
 Some OS X users may experience problems using the pre-built binaries in which case [Homebrew](https://brew.sh) might be a better option:
 
-```
+```sh
 brew install cfssl
 ```
 
 ### Linux
 
-```
+```sh
 wget -q --show-progress --https-only --timestamping \
   https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/linux/cfssl \
   https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/linux/cfssljson
 ```
 
-```
+```sh
 chmod +x cfssl cfssljson
 ```
 
-```
+```sh
 sudo mv cfssl cfssljson /usr/local/bin/
 ```
 
@@ -50,7 +50,7 @@ sudo mv cfssl cfssljson /usr/local/bin/
 
 Verify `cfssl` and `cfssljson` version 1.3.4 or higher is installed:
 
-```
+```sh
 cfssl version
 ```
 
@@ -62,7 +62,7 @@ Revision: dev
 Runtime: go1.13
 ```
 
-```
+```sh
 cfssljson --version
 ```
 ```
@@ -77,29 +77,29 @@ The `kubectl` command line utility is used to interact with the Kubernetes API S
 
 ### OS X
 
-```
+```sh
 curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.15.3/bin/darwin/amd64/kubectl
 ```
 
-```
+```sh
 chmod +x kubectl
 ```
 
-```
+```sh
 sudo mv kubectl /usr/local/bin/
 ```
 
 ### Linux
 
-```
+```sh
 wget https://storage.googleapis.com/kubernetes-release/release/v1.15.3/bin/linux/amd64/kubectl
 ```
 
-```
+```sh
 chmod +x kubectl
 ```
 
-```
+```sh
 sudo mv kubectl /usr/local/bin/
 ```
 
@@ -107,7 +107,7 @@ sudo mv kubectl /usr/local/bin/
 
 Verify `kubectl` version 1.15.3 or higher is installed:
 
-```
+```sh
 kubectl version --client
 ```
 

--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -56,7 +56,7 @@ cfssl version
 
 > output
 
-```plain
+```plaintext
 Version: 1.3.4
 Revision: dev
 Runtime: go1.13
@@ -113,7 +113,7 @@ kubectl version --client
 
 > output
 
-```plain
+```plaintext
 Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.3", GitCommit:"2d3c76f9091b6bec110a5e63777c332469e0cba2", GitTreeState:"clean", BuildDate:"2019-08-19T11:13:54Z", GoVersion:"go1.12.9", Compiler:"gc", Platform:"linux/amd64"}
 ```
 

--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -56,7 +56,7 @@ cfssl version
 
 > output
 
-```
+```plain
 Version: 1.3.4
 Revision: dev
 Runtime: go1.13
@@ -113,7 +113,7 @@ kubectl version --client
 
 > output
 
-```
+```plain
 Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.3", GitCommit:"2d3c76f9091b6bec110a5e63777c332469e0cba2", GitTreeState:"clean", BuildDate:"2019-08-19T11:13:54Z", GoVersion:"go1.12.9", Compiler:"gc", Platform:"linux/amd64"}
 ```
 

--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -16,7 +16,7 @@ In this section a dedicated [Virtual Private Cloud](https://cloud.google.com/com
 
 Create the `kubernetes-the-hard-way` custom VPC network:
 
-```
+```sh
 gcloud compute networks create kubernetes-the-hard-way --subnet-mode custom
 ```
 
@@ -24,7 +24,7 @@ A [subnet](https://cloud.google.com/compute/docs/vpc/#vpc_networks_and_subnets) 
 
 Create the `kubernetes` subnet in the `kubernetes-the-hard-way` VPC network:
 
-```
+```sh
 gcloud compute networks subnets create kubernetes \
   --network kubernetes-the-hard-way \
   --range 10.240.0.0/24
@@ -36,7 +36,7 @@ gcloud compute networks subnets create kubernetes \
 
 Create a firewall rule that allows internal communication across all protocols:
 
-```
+```sh
 gcloud compute firewall-rules create kubernetes-the-hard-way-allow-internal \
   --allow tcp,udp,icmp \
   --network kubernetes-the-hard-way \
@@ -45,7 +45,7 @@ gcloud compute firewall-rules create kubernetes-the-hard-way-allow-internal \
 
 Create a firewall rule that allows external SSH, ICMP, and HTTPS:
 
-```
+```sh
 gcloud compute firewall-rules create kubernetes-the-hard-way-allow-external \
   --allow tcp:22,tcp:6443,icmp \
   --network kubernetes-the-hard-way \
@@ -56,7 +56,7 @@ gcloud compute firewall-rules create kubernetes-the-hard-way-allow-external \
 
 List the firewall rules in the `kubernetes-the-hard-way` VPC network:
 
-```
+```sh
 gcloud compute firewall-rules list --filter="network:kubernetes-the-hard-way"
 ```
 
@@ -72,14 +72,14 @@ kubernetes-the-hard-way-allow-internal  kubernetes-the-hard-way  INGRESS    1000
 
 Allocate a static IP address that will be attached to the external load balancer fronting the Kubernetes API Servers:
 
-```
+```sh
 gcloud compute addresses create kubernetes-the-hard-way \
   --region $(gcloud config get-value compute/region)
 ```
 
 Verify the `kubernetes-the-hard-way` static IP address was created in your default compute region:
 
-```
+```sh
 gcloud compute addresses list --filter="name=('kubernetes-the-hard-way')"
 ```
 
@@ -98,7 +98,7 @@ The compute instances in this lab will be provisioned using [Ubuntu Server](http
 
 Create three compute instances which will host the Kubernetes control plane:
 
-```
+```sh
 for i in 0 1 2; do
   gcloud compute instances create controller-${i} \
     --async \
@@ -122,7 +122,7 @@ Each worker instance requires a pod subnet allocation from the Kubernetes cluste
 
 Create three compute instances which will host the Kubernetes worker nodes:
 
-```
+```sh
 for i in 0 1 2; do
   gcloud compute instances create worker-${i} \
     --async \
@@ -143,7 +143,7 @@ done
 
 List the compute instances in your default compute zone:
 
-```
+```sh
 gcloud compute instances list
 ```
 
@@ -165,7 +165,7 @@ SSH will be used to configure the controller and worker instances. When connecti
 
 Test SSH access to the `controller-0` compute instances:
 
-```
+```sh
 gcloud compute ssh controller-0
 ```
 
@@ -216,7 +216,7 @@ Last login: Sun Sept 14 14:34:27 2019 from XX.XXX.XXX.XX
 
 Type `exit` at the prompt to exit the `controller-0` compute instance:
 
-```
+```sh
 $USER@controller-0:~$ exit
 ```
 > output

--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -62,7 +62,7 @@ gcloud compute firewall-rules list --filter="network:kubernetes-the-hard-way"
 
 > output
 
-```
+```plain
 NAME                                    NETWORK                  DIRECTION  PRIORITY  ALLOW                 DENY
 kubernetes-the-hard-way-allow-external  kubernetes-the-hard-way  INGRESS    1000      tcp:22,tcp:6443,icmp
 kubernetes-the-hard-way-allow-internal  kubernetes-the-hard-way  INGRESS    1000      tcp,udp,icmp
@@ -85,7 +85,7 @@ gcloud compute addresses list --filter="name=('kubernetes-the-hard-way')"
 
 > output
 
-```
+```plain
 NAME                     REGION    ADDRESS        STATUS
 kubernetes-the-hard-way  us-west1  XX.XXX.XXX.XX  RESERVED
 ```
@@ -149,7 +149,7 @@ gcloud compute instances list
 
 > output
 
-```
+```plain
 NAME          ZONE        MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP  EXTERNAL_IP     STATUS
 controller-0  us-west1-c  n1-standard-1               10.240.0.10  XX.XXX.XXX.XXX  RUNNING
 controller-1  us-west1-c  n1-standard-1               10.240.0.11  XX.XXX.X.XX     RUNNING
@@ -171,7 +171,7 @@ gcloud compute ssh controller-0
 
 If this is your first time connecting to a compute instance SSH keys will be generated for you. Enter a passphrase at the prompt to continue:
 
-```
+```plain
 WARNING: The public SSH key file for gcloud does not exist.
 WARNING: The private SSH key file for gcloud does not exist.
 WARNING: You do not have an SSH key for gcloud.
@@ -183,7 +183,7 @@ Enter same passphrase again:
 
 At this point the generated SSH keys will be uploaded and stored in your project:
 
-```
+```plain
 Your identification has been saved in /home/$USER/.ssh/google_compute_engine.
 Your public key has been saved in /home/$USER/.ssh/google_compute_engine.pub.
 The key fingerprint is:
@@ -207,7 +207,7 @@ Waiting for SSH key to propagate.
 
 After the SSH keys have been updated you'll be logged into the `controller-0` instance:
 
-```
+```plain
 Welcome to Ubuntu 18.04.3 LTS (GNU/Linux 4.15.0-1042-gcp x86_64)
 ...
 
@@ -221,7 +221,7 @@ $USER@controller-0:~$ exit
 ```
 > output
 
-```
+```plain
 logout
 Connection to XX.XXX.XXX.XXX closed
 ```

--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -62,7 +62,7 @@ gcloud compute firewall-rules list --filter="network:kubernetes-the-hard-way"
 
 > output
 
-```plain
+```plaintext
 NAME                                    NETWORK                  DIRECTION  PRIORITY  ALLOW                 DENY
 kubernetes-the-hard-way-allow-external  kubernetes-the-hard-way  INGRESS    1000      tcp:22,tcp:6443,icmp
 kubernetes-the-hard-way-allow-internal  kubernetes-the-hard-way  INGRESS    1000      tcp,udp,icmp
@@ -85,7 +85,7 @@ gcloud compute addresses list --filter="name=('kubernetes-the-hard-way')"
 
 > output
 
-```plain
+```plaintext
 NAME                     REGION    ADDRESS        STATUS
 kubernetes-the-hard-way  us-west1  XX.XXX.XXX.XX  RESERVED
 ```
@@ -149,7 +149,7 @@ gcloud compute instances list
 
 > output
 
-```plain
+```plaintext
 NAME          ZONE        MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP  EXTERNAL_IP     STATUS
 controller-0  us-west1-c  n1-standard-1               10.240.0.10  XX.XXX.XXX.XXX  RUNNING
 controller-1  us-west1-c  n1-standard-1               10.240.0.11  XX.XXX.X.XX     RUNNING
@@ -171,7 +171,7 @@ gcloud compute ssh controller-0
 
 If this is your first time connecting to a compute instance SSH keys will be generated for you. Enter a passphrase at the prompt to continue:
 
-```plain
+```plaintext
 WARNING: The public SSH key file for gcloud does not exist.
 WARNING: The private SSH key file for gcloud does not exist.
 WARNING: You do not have an SSH key for gcloud.
@@ -183,7 +183,7 @@ Enter same passphrase again:
 
 At this point the generated SSH keys will be uploaded and stored in your project:
 
-```plain
+```plaintext
 Your identification has been saved in /home/$USER/.ssh/google_compute_engine.
 Your public key has been saved in /home/$USER/.ssh/google_compute_engine.pub.
 The key fingerprint is:
@@ -207,7 +207,7 @@ Waiting for SSH key to propagate.
 
 After the SSH keys have been updated you'll be logged into the `controller-0` instance:
 
-```plain
+```plaintext
 Welcome to Ubuntu 18.04.3 LTS (GNU/Linux 4.15.0-1042-gcp x86_64)
 ...
 
@@ -221,7 +221,7 @@ $USER@controller-0:~$ exit
 ```
 > output
 
-```plain
+```plaintext
 logout
 Connection to XX.XXX.XXX.XXX closed
 ```

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -53,7 +53,7 @@ cfssl gencert -initca ca-csr.json | cfssljson -bare ca
 
 Results:
 
-```
+```plain
 ca-key.pem
 ca.pem
 ```
@@ -100,7 +100,7 @@ cfssl gencert \
 
 Results:
 
-```
+```plain
 admin-key.pem
 admin.pem
 ```
@@ -150,7 +150,7 @@ done
 
 Results:
 
-```
+```plain
 worker-0-key.pem
 worker-0.pem
 worker-1-key.pem
@@ -197,7 +197,7 @@ cfssl gencert \
 
 Results:
 
-```
+```plain
 kube-controller-manager-key.pem
 kube-controller-manager.pem
 ```
@@ -241,7 +241,7 @@ cfssl gencert \
 
 Results:
 
-```
+```plain
 kube-proxy-key.pem
 kube-proxy.pem
 ```
@@ -284,7 +284,7 @@ cfssl gencert \
 
 Results:
 
-```
+```plain
 kube-scheduler-key.pem
 kube-scheduler.pem
 ```
@@ -339,7 +339,7 @@ cfssl gencert \
 
 Results:
 
-```
+```plain
 kubernetes-key.pem
 kubernetes.pem
 ```
@@ -384,7 +384,7 @@ cfssl gencert \
 
 Results:
 
-```
+```plain
 service-account-key.pem
 service-account.pem
 ```

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -8,7 +8,7 @@ In this section you will provision a Certificate Authority that can be used to g
 
 Generate the CA configuration file, certificate, and private key:
 
-```
+```sh
 {
 
 cat > ca-config.json <<EOF
@@ -66,7 +66,7 @@ In this section you will generate client and server certificates for each Kubern
 
 Generate the `admin` client certificate and private key:
 
-```
+```sh
 {
 
 cat > admin-csr.json <<EOF
@@ -111,7 +111,7 @@ Kubernetes uses a [special-purpose authorization mode](https://kubernetes.io/doc
 
 Generate a certificate and private key for each Kubernetes worker node:
 
-```
+```sh
 for instance in worker-0 worker-1 worker-2; do
 cat > ${instance}-csr.json <<EOF
 {
@@ -163,7 +163,7 @@ worker-2.pem
 
 Generate the `kube-controller-manager` client certificate and private key:
 
-```
+```sh
 {
 
 cat > kube-controller-manager-csr.json <<EOF
@@ -207,7 +207,7 @@ kube-controller-manager.pem
 
 Generate the `kube-proxy` client certificate and private key:
 
-```
+```sh
 {
 
 cat > kube-proxy-csr.json <<EOF
@@ -250,7 +250,7 @@ kube-proxy.pem
 
 Generate the `kube-scheduler` client certificate and private key:
 
-```
+```sh
 {
 
 cat > kube-scheduler-csr.json <<EOF
@@ -296,7 +296,7 @@ The `kubernetes-the-hard-way` static IP address will be included in the list of 
 
 Generate the Kubernetes API Server certificate and private key:
 
-```
+```sh
 {
 
 KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
@@ -350,7 +350,7 @@ The Kubernetes Controller Manager leverages a key pair to generate and sign serv
 
 Generate the `service-account` certificate and private key:
 
-```
+```sh
 {
 
 cat > service-account-csr.json <<EOF
@@ -394,7 +394,7 @@ service-account.pem
 
 Copy the appropriate certificates and private keys to each worker instance:
 
-```
+```sh
 for instance in worker-0 worker-1 worker-2; do
   gcloud compute scp ca.pem ${instance}-key.pem ${instance}.pem ${instance}:~/
 done
@@ -402,7 +402,7 @@ done
 
 Copy the appropriate certificates and private keys to each controller instance:
 
-```
+```sh
 for instance in controller-0 controller-1 controller-2; do
   gcloud compute scp ca.pem ca-key.pem kubernetes-key.pem kubernetes.pem \
     service-account-key.pem service-account.pem ${instance}:~/

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -53,7 +53,7 @@ cfssl gencert -initca ca-csr.json | cfssljson -bare ca
 
 Results:
 
-```plain
+```plaintext
 ca-key.pem
 ca.pem
 ```
@@ -100,7 +100,7 @@ cfssl gencert \
 
 Results:
 
-```plain
+```plaintext
 admin-key.pem
 admin.pem
 ```
@@ -150,7 +150,7 @@ done
 
 Results:
 
-```plain
+```plaintext
 worker-0-key.pem
 worker-0.pem
 worker-1-key.pem
@@ -197,7 +197,7 @@ cfssl gencert \
 
 Results:
 
-```plain
+```plaintext
 kube-controller-manager-key.pem
 kube-controller-manager.pem
 ```
@@ -241,7 +241,7 @@ cfssl gencert \
 
 Results:
 
-```plain
+```plaintext
 kube-proxy-key.pem
 kube-proxy.pem
 ```
@@ -284,7 +284,7 @@ cfssl gencert \
 
 Results:
 
-```plain
+```plaintext
 kube-scheduler-key.pem
 kube-scheduler.pem
 ```
@@ -339,7 +339,7 @@ cfssl gencert \
 
 Results:
 
-```plain
+```plaintext
 kubernetes-key.pem
 kubernetes.pem
 ```
@@ -384,7 +384,7 @@ cfssl gencert \
 
 Results:
 
-```plain
+```plaintext
 service-account-key.pem
 service-account.pem
 ```

--- a/docs/05-kubernetes-configuration-files.md
+++ b/docs/05-kubernetes-configuration-files.md
@@ -51,7 +51,7 @@ done
 
 Results:
 
-```
+```plain
 worker-0.kubeconfig
 worker-1.kubeconfig
 worker-2.kubeconfig
@@ -86,7 +86,7 @@ Generate a kubeconfig file for the `kube-proxy` service:
 
 Results:
 
-```
+```plain
 kube-proxy.kubeconfig
 ```
 
@@ -119,7 +119,7 @@ Generate a kubeconfig file for the `kube-controller-manager` service:
 
 Results:
 
-```
+```plain
 kube-controller-manager.kubeconfig
 ```
 
@@ -153,7 +153,7 @@ Generate a kubeconfig file for the `kube-scheduler` service:
 
 Results:
 
-```
+```plain
 kube-scheduler.kubeconfig
 ```
 
@@ -186,7 +186,7 @@ Generate a kubeconfig file for the `admin` user:
 
 Results:
 
-```
+```plain
 admin.kubeconfig
 ```
 

--- a/docs/05-kubernetes-configuration-files.md
+++ b/docs/05-kubernetes-configuration-files.md
@@ -51,7 +51,7 @@ done
 
 Results:
 
-```plain
+```plaintext
 worker-0.kubeconfig
 worker-1.kubeconfig
 worker-2.kubeconfig
@@ -86,7 +86,7 @@ Generate a kubeconfig file for the `kube-proxy` service:
 
 Results:
 
-```plain
+```plaintext
 kube-proxy.kubeconfig
 ```
 
@@ -119,7 +119,7 @@ Generate a kubeconfig file for the `kube-controller-manager` service:
 
 Results:
 
-```plain
+```plaintext
 kube-controller-manager.kubeconfig
 ```
 
@@ -153,7 +153,7 @@ Generate a kubeconfig file for the `kube-scheduler` service:
 
 Results:
 
-```plain
+```plaintext
 kube-scheduler.kubeconfig
 ```
 
@@ -186,7 +186,7 @@ Generate a kubeconfig file for the `admin` user:
 
 Results:
 
-```plain
+```plaintext
 admin.kubeconfig
 ```
 

--- a/docs/05-kubernetes-configuration-files.md
+++ b/docs/05-kubernetes-configuration-files.md
@@ -12,7 +12,7 @@ Each kubeconfig requires a Kubernetes API Server to connect to. To support high 
 
 Retrieve the `kubernetes-the-hard-way` static IP address:
 
-```
+```sh
 KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
   --region $(gcloud config get-value compute/region) \
   --format 'value(address)')
@@ -26,7 +26,7 @@ When generating kubeconfig files for Kubelets the client certificate matching th
 
 Generate a kubeconfig file for each worker node:
 
-```
+```sh
 for instance in worker-0 worker-1 worker-2; do
   kubectl config set-cluster kubernetes-the-hard-way \
     --certificate-authority=ca.pem \
@@ -61,7 +61,7 @@ worker-2.kubeconfig
 
 Generate a kubeconfig file for the `kube-proxy` service:
 
-```
+```sh
 {
   kubectl config set-cluster kubernetes-the-hard-way \
     --certificate-authority=ca.pem \
@@ -94,7 +94,7 @@ kube-proxy.kubeconfig
 
 Generate a kubeconfig file for the `kube-controller-manager` service:
 
-```
+```sh
 {
   kubectl config set-cluster kubernetes-the-hard-way \
     --certificate-authority=ca.pem \
@@ -128,7 +128,7 @@ kube-controller-manager.kubeconfig
 
 Generate a kubeconfig file for the `kube-scheduler` service:
 
-```
+```sh
 {
   kubectl config set-cluster kubernetes-the-hard-way \
     --certificate-authority=ca.pem \
@@ -161,7 +161,7 @@ kube-scheduler.kubeconfig
 
 Generate a kubeconfig file for the `admin` user:
 
-```
+```sh
 {
   kubectl config set-cluster kubernetes-the-hard-way \
     --certificate-authority=ca.pem \
@@ -191,13 +191,13 @@ admin.kubeconfig
 ```
 
 
-## 
+##
 
 ## Distribute the Kubernetes Configuration Files
 
 Copy the appropriate `kubelet` and `kube-proxy` kubeconfig files to each worker instance:
 
-```
+```sh
 for instance in worker-0 worker-1 worker-2; do
   gcloud compute scp ${instance}.kubeconfig kube-proxy.kubeconfig ${instance}:~/
 done
@@ -205,7 +205,7 @@ done
 
 Copy the appropriate `kube-controller-manager` and `kube-scheduler` kubeconfig files to each controller instance:
 
-```
+```sh
 for instance in controller-0 controller-1 controller-2; do
   gcloud compute scp admin.kubeconfig kube-controller-manager.kubeconfig kube-scheduler.kubeconfig ${instance}:~/
 done

--- a/docs/06-data-encryption-keys.md
+++ b/docs/06-data-encryption-keys.md
@@ -8,7 +8,7 @@ In this lab you will generate an encryption key and an [encryption config](https
 
 Generate an encryption key:
 
-```
+```sh
 ENCRYPTION_KEY=$(head -c 32 /dev/urandom | base64)
 ```
 
@@ -16,7 +16,7 @@ ENCRYPTION_KEY=$(head -c 32 /dev/urandom | base64)
 
 Create the `encryption-config.yaml` encryption config file:
 
-```
+```sh
 cat > encryption-config.yaml <<EOF
 kind: EncryptionConfig
 apiVersion: v1
@@ -34,7 +34,7 @@ EOF
 
 Copy the `encryption-config.yaml` encryption config file to each controller instance:
 
-```
+```sh
 for instance in controller-0 controller-1 controller-2; do
   gcloud compute scp encryption-config.yaml ${instance}:~/
 done

--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -6,7 +6,7 @@ Kubernetes components are stateless and store cluster state in [etcd](https://gi
 
 The commands in this lab must be run on each controller instance: `controller-0`, `controller-1`, and `controller-2`. Login to each controller instance using the `gcloud` command. Example:
 
-```
+```sh
 gcloud compute ssh controller-0
 ```
 
@@ -20,14 +20,14 @@ gcloud compute ssh controller-0
 
 Download the official etcd release binaries from the [etcd](https://github.com/etcd-io/etcd) GitHub project:
 
-```
+```sh
 wget -q --show-progress --https-only --timestamping \
   "https://github.com/etcd-io/etcd/releases/download/v3.4.0/etcd-v3.4.0-linux-amd64.tar.gz"
 ```
 
 Extract and install the `etcd` server and the `etcdctl` command line utility:
 
-```
+```sh
 {
   tar -xvf etcd-v3.4.0-linux-amd64.tar.gz
   sudo mv etcd-v3.4.0-linux-amd64/etcd* /usr/local/bin/
@@ -36,7 +36,7 @@ Extract and install the `etcd` server and the `etcdctl` command line utility:
 
 ### Configure the etcd Server
 
-```
+```sh
 {
   sudo mkdir -p /etc/etcd /var/lib/etcd
   sudo cp ca.pem kubernetes-key.pem kubernetes.pem /etc/etcd/
@@ -45,20 +45,20 @@ Extract and install the `etcd` server and the `etcdctl` command line utility:
 
 The instance internal IP address will be used to serve client requests and communicate with etcd cluster peers. Retrieve the internal IP address for the current compute instance:
 
-```
+```sh
 INTERNAL_IP=$(curl -s -H "Metadata-Flavor: Google" \
   http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip)
 ```
 
 Each etcd member must have a unique name within an etcd cluster. Set the etcd name to match the hostname of the current compute instance:
 
-```
+```sh
 ETCD_NAME=$(hostname -s)
 ```
 
 Create the `etcd.service` systemd unit file:
 
-```
+```sh
 cat <<EOF | sudo tee /etc/systemd/system/etcd.service
 [Unit]
 Description=etcd
@@ -94,7 +94,7 @@ EOF
 
 ### Start the etcd Server
 
-```
+```sh
 {
   sudo systemctl daemon-reload
   sudo systemctl enable etcd
@@ -108,7 +108,7 @@ EOF
 
 List the etcd cluster members:
 
-```
+```sh
 sudo ETCDCTL_API=3 etcdctl member list \
   --endpoints=https://127.0.0.1:2379 \
   --cacert=/etc/etcd/ca.pem \

--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -118,7 +118,7 @@ sudo ETCDCTL_API=3 etcdctl member list \
 
 > output
 
-```plain
+```plaintext
 3a57933972cb5131, started, controller-2, https://10.240.0.12:2380, https://10.240.0.12:2379
 f98dc20bce6225a0, started, controller-0, https://10.240.0.10:2380, https://10.240.0.10:2379
 ffed16798470cab5, started, controller-1, https://10.240.0.11:2380, https://10.240.0.11:2379

--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -118,7 +118,7 @@ sudo ETCDCTL_API=3 etcdctl member list \
 
 > output
 
-```
+```plain
 3a57933972cb5131, started, controller-2, https://10.240.0.12:2380, https://10.240.0.12:2379
 f98dc20bce6225a0, started, controller-0, https://10.240.0.10:2380, https://10.240.0.10:2379
 ffed16798470cab5, started, controller-1, https://10.240.0.11:2380, https://10.240.0.11:2379

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -249,7 +249,7 @@ sudo systemctl enable nginx
 kubectl get componentstatuses --kubeconfig admin.kubeconfig
 ```
 
-```
+```plain
 NAME                 STATUS    MESSAGE              ERROR
 controller-manager   Healthy   ok
 scheduler            Healthy   ok
@@ -264,7 +264,7 @@ Test the nginx HTTP health check proxy:
 curl -H "Host: kubernetes.default.svc.cluster.local" -i http://127.0.0.1/healthz
 ```
 
-```
+```plain
 HTTP/1.1 200 OK
 Server: nginx/1.14.0 (Ubuntu)
 Date: Sat, 14 Sep 2019 18:34:11 GMT

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -249,7 +249,7 @@ sudo systemctl enable nginx
 kubectl get componentstatuses --kubeconfig admin.kubeconfig
 ```
 
-```plain
+```plaintext
 NAME                 STATUS    MESSAGE              ERROR
 controller-manager   Healthy   ok
 scheduler            Healthy   ok
@@ -264,7 +264,7 @@ Test the nginx HTTP health check proxy:
 curl -H "Host: kubernetes.default.svc.cluster.local" -i http://127.0.0.1/healthz
 ```
 
-```plain
+```plaintext
 HTTP/1.1 200 OK
 Server: nginx/1.14.0 (Ubuntu)
 Date: Sat, 14 Sep 2019 18:34:11 GMT

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -303,7 +303,7 @@ gcloud compute ssh controller-0 \
 
 > output
 
-```
+```plain
 NAME       STATUS   ROLES    AGE   VERSION
 worker-0   Ready    <none>   15s   v1.15.3
 worker-1   Ready    <none>   15s   v1.15.3

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -303,7 +303,7 @@ gcloud compute ssh controller-0 \
 
 > output
 
-```plain
+```plaintext
 NAME       STATUS   ROLES    AGE   VERSION
 worker-0   Ready    <none>   15s   v1.15.3
 worker-1   Ready    <none>   15s   v1.15.3

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -6,7 +6,7 @@ In this lab you will bootstrap three Kubernetes worker nodes. The following comp
 
 The commands in this lab must be run on each worker instance: `worker-0`, `worker-1`, and `worker-2`. Login to each worker instance using the `gcloud` command. Example:
 
-```
+```sh
 gcloud compute ssh worker-0
 ```
 
@@ -18,7 +18,7 @@ gcloud compute ssh worker-0
 
 Install the OS dependencies:
 
-```
+```sh
 {
   sudo apt-get update
   sudo apt-get -y install socat conntrack ipset
@@ -33,13 +33,13 @@ By default the kubelet will fail to start if [swap](https://help.ubuntu.com/comm
 
 Verify if swap is enabled:
 
-```
+```sh
 sudo swapon --show
 ```
 
 If output is empthy then swap is not enabled. If swap is enabled run the following command to disable swap immediately:
 
-```
+```sh
 sudo swapoff -a
 ```
 
@@ -47,7 +47,7 @@ sudo swapoff -a
 
 ### Download and Install Worker Binaries
 
-```
+```sh
 wget -q --show-progress --https-only --timestamping \
   https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.15.0/crictl-v1.15.0-linux-amd64.tar.gz \
   https://github.com/opencontainers/runc/releases/download/v1.0.0-rc8/runc.amd64 \
@@ -60,7 +60,7 @@ wget -q --show-progress --https-only --timestamping \
 
 Create the installation directories:
 
-```
+```sh
 sudo mkdir -p \
   /etc/cni/net.d \
   /opt/cni/bin \
@@ -72,14 +72,14 @@ sudo mkdir -p \
 
 Install the worker binaries:
 
-```
+```sh
 {
   mkdir containerd
   tar -xvf crictl-v1.15.0-linux-amd64.tar.gz
   tar -xvf containerd-1.2.9.linux-amd64.tar.gz -C containerd
   sudo tar -xvf cni-plugins-linux-amd64-v0.8.2.tgz -C /opt/cni/bin/
   sudo mv runc.amd64 runc
-  chmod +x crictl kubectl kube-proxy kubelet runc 
+  chmod +x crictl kubectl kube-proxy kubelet runc
   sudo mv crictl kubectl kube-proxy kubelet runc /usr/local/bin/
   sudo mv containerd/bin/* /bin/
 }
@@ -89,14 +89,14 @@ Install the worker binaries:
 
 Retrieve the Pod CIDR range for the current compute instance:
 
-```
+```sh
 POD_CIDR=$(curl -s -H "Metadata-Flavor: Google" \
   http://metadata.google.internal/computeMetadata/v1/instance/attributes/pod-cidr)
 ```
 
 Create the `bridge` network configuration file:
 
-```
+```sh
 cat <<EOF | sudo tee /etc/cni/net.d/10-bridge.conf
 {
     "cniVersion": "0.3.1",
@@ -118,7 +118,7 @@ EOF
 
 Create the `loopback` network configuration file:
 
-```
+```sh
 cat <<EOF | sudo tee /etc/cni/net.d/99-loopback.conf
 {
     "cniVersion": "0.3.1",
@@ -132,11 +132,11 @@ EOF
 
 Create the `containerd` configuration file:
 
-```
+```sh
 sudo mkdir -p /etc/containerd/
 ```
 
-```
+```sh
 cat << EOF | sudo tee /etc/containerd/config.toml
 [plugins]
   [plugins.cri.containerd]
@@ -150,7 +150,7 @@ EOF
 
 Create the `containerd.service` systemd unit file:
 
-```
+```sh
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service
 [Unit]
 Description=containerd container runtime
@@ -176,7 +176,7 @@ EOF
 
 ### Configure the Kubelet
 
-```
+```sh
 {
   sudo mv ${HOSTNAME}-key.pem ${HOSTNAME}.pem /var/lib/kubelet/
   sudo mv ${HOSTNAME}.kubeconfig /var/lib/kubelet/kubeconfig
@@ -186,7 +186,7 @@ EOF
 
 Create the `kubelet-config.yaml` configuration file:
 
-```
+```sh
 cat <<EOF | sudo tee /var/lib/kubelet/kubelet-config.yaml
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
@@ -210,11 +210,11 @@ tlsPrivateKeyFile: "/var/lib/kubelet/${HOSTNAME}-key.pem"
 EOF
 ```
 
-> The `resolvConf` configuration is used to avoid loops when using CoreDNS for service discovery on systems running `systemd-resolved`. 
+> The `resolvConf` configuration is used to avoid loops when using CoreDNS for service discovery on systems running `systemd-resolved`.
 
 Create the `kubelet.service` systemd unit file:
 
-```
+```sh
 cat <<EOF | sudo tee /etc/systemd/system/kubelet.service
 [Unit]
 Description=Kubernetes Kubelet
@@ -242,13 +242,13 @@ EOF
 
 ### Configure the Kubernetes Proxy
 
-```
+```sh
 sudo mv kube-proxy.kubeconfig /var/lib/kube-proxy/kubeconfig
 ```
 
 Create the `kube-proxy-config.yaml` configuration file:
 
-```
+```sh
 cat <<EOF | sudo tee /var/lib/kube-proxy/kube-proxy-config.yaml
 kind: KubeProxyConfiguration
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
@@ -261,7 +261,7 @@ EOF
 
 Create the `kube-proxy.service` systemd unit file:
 
-```
+```sh
 cat <<EOF | sudo tee /etc/systemd/system/kube-proxy.service
 [Unit]
 Description=Kubernetes Kube Proxy
@@ -280,7 +280,7 @@ EOF
 
 ### Start the Worker Services
 
-```
+```sh
 {
   sudo systemctl daemon-reload
   sudo systemctl enable containerd kubelet kube-proxy
@@ -296,7 +296,7 @@ EOF
 
 List the registered Kubernetes nodes:
 
-```
+```sh
 gcloud compute ssh controller-0 \
   --command "kubectl get nodes --kubeconfig admin.kubeconfig"
 ```

--- a/docs/10-configuring-kubectl.md
+++ b/docs/10-configuring-kubectl.md
@@ -43,7 +43,7 @@ kubectl get componentstatuses
 
 > output
 
-```plain
+```plaintext
 NAME                 STATUS    MESSAGE             ERROR
 controller-manager   Healthy   ok
 scheduler            Healthy   ok
@@ -60,7 +60,7 @@ kubectl get nodes
 
 > output
 
-```plain
+```plaintext
 NAME       STATUS   ROLES    AGE    VERSION
 worker-0   Ready    <none>   2m9s   v1.15.3
 worker-1   Ready    <none>   2m9s   v1.15.3

--- a/docs/10-configuring-kubectl.md
+++ b/docs/10-configuring-kubectl.md
@@ -43,7 +43,7 @@ kubectl get componentstatuses
 
 > output
 
-```
+```plain
 NAME                 STATUS    MESSAGE             ERROR
 controller-manager   Healthy   ok
 scheduler            Healthy   ok
@@ -60,7 +60,7 @@ kubectl get nodes
 
 > output
 
-```
+```plain
 NAME       STATUS   ROLES    AGE    VERSION
 worker-0   Ready    <none>   2m9s   v1.15.3
 worker-1   Ready    <none>   2m9s   v1.15.3

--- a/docs/10-configuring-kubectl.md
+++ b/docs/10-configuring-kubectl.md
@@ -10,7 +10,7 @@ Each kubeconfig requires a Kubernetes API Server to connect to. To support high 
 
 Generate a kubeconfig file suitable for authenticating as the `admin` user:
 
-```
+```sh
 {
   KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-hard-way \
     --region $(gcloud config get-value compute/region) \
@@ -37,7 +37,7 @@ Generate a kubeconfig file suitable for authenticating as the `admin` user:
 
 Check the health of the remote Kubernetes cluster:
 
-```
+```sh
 kubectl get componentstatuses
 ```
 
@@ -54,7 +54,7 @@ etcd-0               Healthy   {"health":"true"}
 
 List the nodes in the remote Kubernetes cluster:
 
-```
+```sh
 kubectl get nodes
 ```
 

--- a/docs/11-pod-network-routes.md
+++ b/docs/11-pod-network-routes.md
@@ -12,7 +12,7 @@ In this section you will gather the information required to create routes in the
 
 Print the internal IP address and Pod CIDR range for each worker instance:
 
-```
+```sh
 for instance in worker-0 worker-1 worker-2; do
   gcloud compute instances describe ${instance} \
     --format 'value[separator=" "](networkInterfaces[0].networkIP,metadata.items[0].value)'
@@ -31,7 +31,7 @@ done
 
 Create network routes for each worker instance:
 
-```
+```sh
 for i in 0 1 2; do
   gcloud compute routes create kubernetes-route-10-200-${i}-0-24 \
     --network kubernetes-the-hard-way \
@@ -42,7 +42,7 @@ done
 
 List the routes in the `kubernetes-the-hard-way` VPC network:
 
-```
+```sh
 gcloud compute routes list --filter "network: kubernetes-the-hard-way"
 ```
 

--- a/docs/11-pod-network-routes.md
+++ b/docs/11-pod-network-routes.md
@@ -21,7 +21,7 @@ done
 
 > output
 
-```
+```plain
 10.240.0.20 10.200.0.0/24
 10.240.0.21 10.200.1.0/24
 10.240.0.22 10.200.2.0/24
@@ -48,7 +48,7 @@ gcloud compute routes list --filter "network: kubernetes-the-hard-way"
 
 > output
 
-```
+```plain
 NAME                            NETWORK                  DEST_RANGE     NEXT_HOP                  PRIORITY
 default-route-081879136902de56  kubernetes-the-hard-way  10.240.0.0/24  kubernetes-the-hard-way   1000
 default-route-55199a5aa126d7aa  kubernetes-the-hard-way  0.0.0.0/0      default-internet-gateway  1000

--- a/docs/11-pod-network-routes.md
+++ b/docs/11-pod-network-routes.md
@@ -21,7 +21,7 @@ done
 
 > output
 
-```plain
+```plaintext
 10.240.0.20 10.200.0.0/24
 10.240.0.21 10.200.1.0/24
 10.240.0.22 10.200.2.0/24
@@ -48,7 +48,7 @@ gcloud compute routes list --filter "network: kubernetes-the-hard-way"
 
 > output
 
-```plain
+```plaintext
 NAME                            NETWORK                  DEST_RANGE     NEXT_HOP                  PRIORITY
 default-route-081879136902de56  kubernetes-the-hard-way  10.240.0.0/24  kubernetes-the-hard-way   1000
 default-route-55199a5aa126d7aa  kubernetes-the-hard-way  0.0.0.0/0      default-internet-gateway  1000

--- a/docs/12-dns-addon.md
+++ b/docs/12-dns-addon.md
@@ -12,7 +12,7 @@ kubectl apply -f https://storage.googleapis.com/kubernetes-the-hard-way/coredns.
 
 > output
 
-```plain
+```plaintext
 serviceaccount/coredns created
 clusterrole.rbac.authorization.k8s.io/system:coredns created
 clusterrolebinding.rbac.authorization.k8s.io/system:coredns created
@@ -29,7 +29,7 @@ kubectl get pods -l k8s-app=kube-dns -n kube-system
 
 > output
 
-```plain
+```plaintext
 NAME                       READY   STATUS    RESTARTS   AGE
 coredns-699f8ddd77-94qv9   1/1     Running   0          20s
 coredns-699f8ddd77-gtcgb   1/1     Running   0          20s
@@ -51,7 +51,7 @@ kubectl get pods -l run=busybox
 
 > output
 
-```plain
+```plaintext
 NAME      READY   STATUS    RESTARTS   AGE
 busybox   1/1     Running   0          3s
 ```
@@ -70,7 +70,7 @@ kubectl exec -ti $POD_NAME -- nslookup kubernetes
 
 > output
 
-```plain
+```plaintext
 Server:    10.32.0.10
 Address 1: 10.32.0.10 kube-dns.kube-system.svc.cluster.local
 

--- a/docs/12-dns-addon.md
+++ b/docs/12-dns-addon.md
@@ -12,7 +12,7 @@ kubectl apply -f https://storage.googleapis.com/kubernetes-the-hard-way/coredns.
 
 > output
 
-```
+```plain
 serviceaccount/coredns created
 clusterrole.rbac.authorization.k8s.io/system:coredns created
 clusterrolebinding.rbac.authorization.k8s.io/system:coredns created
@@ -29,7 +29,7 @@ kubectl get pods -l k8s-app=kube-dns -n kube-system
 
 > output
 
-```
+```plain
 NAME                       READY   STATUS    RESTARTS   AGE
 coredns-699f8ddd77-94qv9   1/1     Running   0          20s
 coredns-699f8ddd77-gtcgb   1/1     Running   0          20s
@@ -51,7 +51,7 @@ kubectl get pods -l run=busybox
 
 > output
 
-```
+```plain
 NAME      READY   STATUS    RESTARTS   AGE
 busybox   1/1     Running   0          3s
 ```
@@ -70,7 +70,7 @@ kubectl exec -ti $POD_NAME -- nslookup kubernetes
 
 > output
 
-```
+```plain
 Server:    10.32.0.10
 Address 1: 10.32.0.10 kube-dns.kube-system.svc.cluster.local
 

--- a/docs/12-dns-addon.md
+++ b/docs/12-dns-addon.md
@@ -6,7 +6,7 @@ In this lab you will deploy the [DNS add-on](https://kubernetes.io/docs/concepts
 
 Deploy the `coredns` cluster add-on:
 
-```
+```sh
 kubectl apply -f https://storage.googleapis.com/kubernetes-the-hard-way/coredns.yaml
 ```
 
@@ -23,7 +23,7 @@ service/kube-dns created
 
 List the pods created by the `kube-dns` deployment:
 
-```
+```sh
 kubectl get pods -l k8s-app=kube-dns -n kube-system
 ```
 
@@ -39,13 +39,13 @@ coredns-699f8ddd77-gtcgb   1/1     Running   0          20s
 
 Create a `busybox` deployment:
 
-```
+```sh
 kubectl run --generator=run-pod/v1 busybox --image=busybox:1.28 --command -- sleep 3600
 ```
 
 List the pod created by the `busybox` deployment:
 
-```
+```sh
 kubectl get pods -l run=busybox
 ```
 
@@ -58,13 +58,13 @@ busybox   1/1     Running   0          3s
 
 Retrieve the full name of the `busybox` pod:
 
-```
+```sh
 POD_NAME=$(kubectl get pods -l run=busybox -o jsonpath="{.items[0].metadata.name}")
 ```
 
 Execute a DNS lookup for the `kubernetes` service inside the `busybox` pod:
 
-```
+```sh
 kubectl exec -ti $POD_NAME -- nslookup kubernetes
 ```
 

--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -27,7 +27,7 @@ gcloud compute ssh controller-0 \
 
 > output
 
-```
+```plain
 00000000  2f 72 65 67 69 73 74 72  79 2f 73 65 63 72 65 74  |/registry/secret|
 00000010  73 2f 64 65 66 61 75 6c  74 2f 6b 75 62 65 72 6e  |s/default/kubern|
 00000020  65 74 65 73 2d 74 68 65  2d 68 61 72 64 2d 77 61  |etes-the-hard-wa|
@@ -65,7 +65,7 @@ kubectl get pods -l app=nginx
 
 > output
 
-```
+```plain
 NAME                     READY   STATUS    RESTARTS   AGE
 nginx-554b9c67f9-vt5rn   1/1     Running   0          10s
 ```
@@ -88,7 +88,7 @@ kubectl port-forward $POD_NAME 8080:80
 
 > output
 
-```
+```plain
 Forwarding from 127.0.0.1:8080 -> 80
 Forwarding from [::1]:8080 -> 80
 ```
@@ -101,7 +101,7 @@ curl --head http://127.0.0.1:8080
 
 > output
 
-```
+```plain
 HTTP/1.1 200 OK
 Server: nginx/1.17.3
 Date: Sat, 14 Sep 2019 21:10:11 GMT
@@ -115,7 +115,7 @@ Accept-Ranges: bytes
 
 Switch back to the previous terminal and stop the port forwarding to the `nginx` pod:
 
-```
+```plain
 Forwarding from 127.0.0.1:8080 -> 80
 Forwarding from [::1]:8080 -> 80
 Handling connection for 8080
@@ -134,7 +134,7 @@ kubectl logs $POD_NAME
 
 > output
 
-```
+```plain
 127.0.0.1 - - [14/Sep/2019:21:10:11 +0000] "HEAD / HTTP/1.1" 200 0 "-" "curl/7.52.1" "-"
 ```
 
@@ -150,7 +150,7 @@ kubectl exec -ti $POD_NAME -- nginx -v
 
 > output
 
-```
+```plain
 nginx version: nginx/1.17.3
 ```
 
@@ -196,7 +196,7 @@ curl -I http://${EXTERNAL_IP}:${NODE_PORT}
 
 > output
 
-```
+```plain
 HTTP/1.1 200 OK
 Server: nginx/1.17.3
 Date: Sat, 14 Sep 2019 21:12:35 GMT

--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -8,14 +8,14 @@ In this section you will verify the ability to [encrypt secret data at rest](htt
 
 Create a generic secret:
 
-```
+```sh
 kubectl create secret generic kubernetes-the-hard-way \
   --from-literal="mykey=mydata"
 ```
 
 Print a hexdump of the `kubernetes-the-hard-way` secret stored in etcd:
 
-```
+```sh
 gcloud compute ssh controller-0 \
   --command "sudo ETCDCTL_API=3 etcdctl get \
   --endpoints=https://127.0.0.1:2379 \
@@ -53,13 +53,13 @@ In this section you will verify the ability to create and manage [Deployments](h
 
 Create a deployment for the [nginx](https://nginx.org/en/) web server:
 
-```
+```sh
 kubectl create deployment nginx --image=nginx
 ```
 
 List the pod created by the `nginx` deployment:
 
-```
+```sh
 kubectl get pods -l app=nginx
 ```
 
@@ -76,13 +76,13 @@ In this section you will verify the ability to access applications remotely usin
 
 Retrieve the full name of the `nginx` pod:
 
-```
+```sh
 POD_NAME=$(kubectl get pods -l app=nginx -o jsonpath="{.items[0].metadata.name}")
 ```
 
 Forward port `8080` on your local machine to port `80` of the `nginx` pod:
 
-```
+```sh
 kubectl port-forward $POD_NAME 8080:80
 ```
 
@@ -95,7 +95,7 @@ Forwarding from [::1]:8080 -> 80
 
 In a new terminal make an HTTP request using the forwarding address:
 
-```
+```sh
 curl --head http://127.0.0.1:8080
 ```
 
@@ -128,7 +128,7 @@ In this section you will verify the ability to [retrieve container logs](https:/
 
 Print the `nginx` pod logs:
 
-```
+```sh
 kubectl logs $POD_NAME
 ```
 
@@ -144,7 +144,7 @@ In this section you will verify the ability to [execute commands in a container]
 
 Print the nginx version by executing the `nginx -v` command in the `nginx` container:
 
-```
+```sh
 kubectl exec -ti $POD_NAME -- nginx -v
 ```
 
@@ -160,7 +160,7 @@ In this section you will verify the ability to expose applications using a [Serv
 
 Expose the `nginx` deployment using a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) service:
 
-```
+```sh
 kubectl expose deployment nginx --port 80 --type NodePort
 ```
 
@@ -168,14 +168,14 @@ kubectl expose deployment nginx --port 80 --type NodePort
 
 Retrieve the node port assigned to the `nginx` service:
 
-```
+```sh
 NODE_PORT=$(kubectl get svc nginx \
   --output=jsonpath='{range .spec.ports[0]}{.nodePort}')
 ```
 
 Create a firewall rule that allows remote access to the `nginx` node port:
 
-```
+```sh
 gcloud compute firewall-rules create kubernetes-the-hard-way-allow-nginx-service \
   --allow=tcp:${NODE_PORT} \
   --network kubernetes-the-hard-way
@@ -183,14 +183,14 @@ gcloud compute firewall-rules create kubernetes-the-hard-way-allow-nginx-service
 
 Retrieve the external IP address of a worker instance:
 
-```
+```sh
 EXTERNAL_IP=$(gcloud compute instances describe worker-0 \
   --format 'value(networkInterfaces[0].accessConfigs[0].natIP)')
 ```
 
 Make an HTTP request using the external IP address and the `nginx` node port:
 
-```
+```sh
 curl -I http://${EXTERNAL_IP}:${NODE_PORT}
 ```
 

--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -27,7 +27,7 @@ gcloud compute ssh controller-0 \
 
 > output
 
-```plain
+```plaintext
 00000000  2f 72 65 67 69 73 74 72  79 2f 73 65 63 72 65 74  |/registry/secret|
 00000010  73 2f 64 65 66 61 75 6c  74 2f 6b 75 62 65 72 6e  |s/default/kubern|
 00000020  65 74 65 73 2d 74 68 65  2d 68 61 72 64 2d 77 61  |etes-the-hard-wa|
@@ -65,7 +65,7 @@ kubectl get pods -l app=nginx
 
 > output
 
-```plain
+```plaintext
 NAME                     READY   STATUS    RESTARTS   AGE
 nginx-554b9c67f9-vt5rn   1/1     Running   0          10s
 ```
@@ -88,7 +88,7 @@ kubectl port-forward $POD_NAME 8080:80
 
 > output
 
-```plain
+```plaintext
 Forwarding from 127.0.0.1:8080 -> 80
 Forwarding from [::1]:8080 -> 80
 ```
@@ -101,7 +101,7 @@ curl --head http://127.0.0.1:8080
 
 > output
 
-```plain
+```plaintext
 HTTP/1.1 200 OK
 Server: nginx/1.17.3
 Date: Sat, 14 Sep 2019 21:10:11 GMT
@@ -115,7 +115,7 @@ Accept-Ranges: bytes
 
 Switch back to the previous terminal and stop the port forwarding to the `nginx` pod:
 
-```plain
+```plaintext
 Forwarding from 127.0.0.1:8080 -> 80
 Forwarding from [::1]:8080 -> 80
 Handling connection for 8080
@@ -134,7 +134,7 @@ kubectl logs $POD_NAME
 
 > output
 
-```plain
+```plaintext
 127.0.0.1 - - [14/Sep/2019:21:10:11 +0000] "HEAD / HTTP/1.1" 200 0 "-" "curl/7.52.1" "-"
 ```
 
@@ -150,7 +150,7 @@ kubectl exec -ti $POD_NAME -- nginx -v
 
 > output
 
-```plain
+```plaintext
 nginx version: nginx/1.17.3
 ```
 
@@ -196,7 +196,7 @@ curl -I http://${EXTERNAL_IP}:${NODE_PORT}
 
 > output
 
-```plain
+```plaintext
 HTTP/1.1 200 OK
 Server: nginx/1.17.3
 Date: Sat, 14 Sep 2019 21:12:35 GMT

--- a/docs/14-cleanup.md
+++ b/docs/14-cleanup.md
@@ -6,7 +6,7 @@ In this lab you will delete the compute resources created during this tutorial.
 
 Delete the controller and worker compute instances:
 
-```
+```sh
 gcloud -q compute instances delete \
   controller-0 controller-1 controller-2 \
   worker-0 worker-1 worker-2 \
@@ -17,7 +17,7 @@ gcloud -q compute instances delete \
 
 Delete the external load balancer network resources:
 
-```
+```sh
 {
   gcloud -q compute forwarding-rules delete kubernetes-forwarding-rule \
     --region $(gcloud config get-value compute/region)
@@ -32,7 +32,7 @@ Delete the external load balancer network resources:
 
 Delete the `kubernetes-the-hard-way` firewall rules:
 
-```
+```sh
 gcloud -q compute firewall-rules delete \
   kubernetes-the-hard-way-allow-nginx-service \
   kubernetes-the-hard-way-allow-internal \
@@ -42,7 +42,7 @@ gcloud -q compute firewall-rules delete \
 
 Delete the `kubernetes-the-hard-way` network VPC:
 
-```
+```sh
 {
   gcloud -q compute routes delete \
     kubernetes-route-10-200-0-0-24 \


### PR DESCRIPTION
This PR: 
- adds syntax highlighting to the shell commands and one `json` output
- marks output and results as `plaintext` so highlighting won't be incorrectly applied
- trims trailing whitespace

This makes it easier to read the commands in various places.

In an editor (sublime):
![image](https://user-images.githubusercontent.com/191691/86489300-ed452400-bd31-11ea-927d-8e88fbf0a7bd.png)

In the terminal (using [bat](https://github.com/sharkdp/bat)):
![image](https://user-images.githubusercontent.com/191691/86489222-afe09680-bd31-11ea-9ba4-e04234f413d6.png)

Unfortunately it doesn't change how github renders syntax highlighting for shell commends too much:
![image](https://user-images.githubusercontent.com/191691/86489408-4319cc00-bd32-11ea-9de2-d285fb9a5d3b.png)


