### PR TITLE
Remove the `--network-plugin=cni` kublet option.

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -229,7 +229,6 @@ ExecStart=/usr/local/bin/kubelet \\
   --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock \\
   --image-pull-progress-deadline=2m \\
   --kubeconfig=/var/lib/kubelet/kubeconfig \\
-  --network-plugin=cni \\
   --register-node=true \\
   --v=2
 Restart=on-failure


### PR DESCRIPTION
Remove the `--network-plugin=cni` kublet option. As per the [documentation](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/), this is Docker-specific option and has no effect for the remote/containerd runtime that is being used here. This may be misleading for people that want to go further beyond this guide and modify their clusters.