### PR TITLE
Include flag to authenticate with the kube-controller-manager kubeconfig

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -79,6 +79,7 @@ ExecStart=/usr/local/bin/kube-apiserver \\
   --audit-log-maxbackup=3 \\
   --audit-log-maxsize=100 \\
   --audit-log-path=/var/log/audit.log \\
+  --authentication-kubeconfig=/var/lib/kubernetes/kube-controller-manager.kubeconfig \\
   --authorization-mode=Node,RBAC \\
   --bind-address=0.0.0.0 \\
   --client-ca-file=/var/lib/kubernetes/ca.pem \\
@@ -344,7 +345,6 @@ EOF
 In this section you will provision an external load balancer to front the Kubernetes API Servers. The `kubernetes-the-hard-way` static IP address will be attached to the resulting load balancer.
 
 > The compute instances created in this tutorial will not have permission to complete this section. **Run the following commands from the same machine used to create the compute instances**.
-
 
 ### Provision a Network Load Balancer
 


### PR DESCRIPTION
While going through [Deploying the DNS Cluster Add-on](https://github.com/kelseyhightower/kubernetes-the-hard-way/blob/master/docs/12-dns-addon.md), I attempted to apply the `coredns` cluster add-on, but ran into an authentication issue on my controllers:

```
Oct 01 14:18:10 controller-0 kube-controller-manager[3945]: E1001 14:18:10.611587    3945 leaderelection.go:320] error retrieving resource lock kube-system/kube-controller-manager: endpoints "kube-controller-manager" is forbidden: User "system:anonymous" cannot get resource "endpoints" in API group "" in the namespace "kube-system"
```

Once I modified the service file to authenticate with the `kube-controller-manager.kubeconfig` file and applied to all 3 controllers, ran `sudo systemctl daemon-reload`, and restarted services (`sudo systemctl restart kube-apiserver kube-controller-manager kube-scheduler`), I was able to successfully continue with the guide.

Please let me know if you need more information.

