### PR TITLE
Remove --event-ttl flag due to redundancy.

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -87,7 +87,6 @@ ExecStart=/usr/local/bin/kube-apiserver \\
   --etcd-certfile=/var/lib/kubernetes/kubernetes.pem \\
   --etcd-keyfile=/var/lib/kubernetes/kubernetes-key.pem \\
   --etcd-servers=https://10.240.0.10:2379,https://10.240.0.11:2379,https://10.240.0.12:2379 \\
-  --event-ttl=1h \\
   --encryption-provider-config=/var/lib/kubernetes/encryption-config.yaml \\
   --kubelet-certificate-authority=/var/lib/kubernetes/ca.pem \\
   --kubelet-client-certificate=/var/lib/kubernetes/kubernetes.pem \\


### PR DESCRIPTION
--event-ttl=1h is a default value in 1.18.10 Recommend removal as stating 1h is redundant when the default value is 1h.  
See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/