### PR TITLE
Remove ability for anonymous authentication

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -74,6 +74,7 @@ Documentation=https://github.com/kubernetes/kubernetes
 ExecStart=/usr/local/bin/kube-apiserver \\
   --advertise-address=${INTERNAL_IP} \\
   --allow-privileged=true \\
+  --anonymous-auth=false \\
   --apiserver-count=3 \\
   --audit-log-maxage=30 \\
   --audit-log-maxbackup=3 \\


### PR DESCRIPTION
Add --anonymous-auth=false \\
As the default allows anonymous authentication
--anonymous-auth     Default: true
Enables anonymous requests to the secure port of the API server. Requests that are not rejected by another authentication method are treated as anonymous requests. Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated.

Reference: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/