### PR TITLE
Remove --kubelet-https?

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -92,7 +92,6 @@ ExecStart=/usr/local/bin/kube-apiserver \\
   --kubelet-certificate-authority=/var/lib/kubernetes/ca.pem \\
   --kubelet-client-certificate=/var/lib/kubernetes/kubernetes.pem \\
   --kubelet-client-key=/var/lib/kubernetes/kubernetes-key.pem \\
-  --kubelet-https=true \\
   --runtime-config='api/all=true' \\
   --service-account-key-file=/var/lib/kubernetes/service-account.pem \\
   --service-cluster-ip-range=10.32.0.0/24 \\


### PR DESCRIPTION
I can not find any reference to --kubelet-https in the docs.
Maybe it was relevant at one point and no longer is, maybe it is still relevant and kube-apiserver docs need to be updated.

https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/