### PR TITLE
Update 09-bootstrapping-kubernetes-workers.md

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -37,7 +37,7 @@ Verify if swap is enabled:
 sudo swapon --show
 ```
 
-If output is empthy then swap is not enabled. If swap is enabled run the following command to disable swap immediately:
+If output is empty then swap is not enabled. If swap is enabled run the following command to disable swap immediately:
 
 ```
 sudo swapoff -a


### PR DESCRIPTION
Changed word "empthy" to "empty" under Disable Swap section. Unsure of author's intent.