### PR TITLE
Updated to K8S v1.19.4 amongst others

### DIFF
--- a/deployments/coredns-1.8.0.yaml
+++ b/deployments/coredns-1.8.0.yaml
@@ -98,7 +98,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: coredns/coredns:1.7.0
+        image: coredns/coredns:1.8.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -22,15 +22,15 @@ Download the official etcd release binaries from the [etcd](https://github.com/e
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  "https://github.com/etcd-io/etcd/releases/download/v3.4.10/etcd-v3.4.10-linux-amd64.tar.gz"
+  "https://github.com/etcd-io/etcd/releases/download/v3.4.14/etcd-v3.4.14-linux-amd64.tar.gz"
 ```
 
 Extract and install the `etcd` server and the `etcdctl` command line utility:
 
 ```
 {
-  tar -xvf etcd-v3.4.10-linux-amd64.tar.gz
-  sudo mv etcd-v3.4.10-linux-amd64/etcd* /usr/local/bin/
+  tar -xvf etcd-v3.4.14-linux-amd64.tar.gz
+  sudo mv etcd-v3.4.14-linux-amd64/etcd* /usr/local/bin/
 }
 ```
 

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -28,10 +28,10 @@ Download the official Kubernetes release binaries:
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kube-apiserver" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kube-controller-manager" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kube-scheduler" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl"
+  "https://storage.googleapis.com/kubernetes-release/release/v1.19.4/bin/linux/amd64/kube-apiserver" \
+  "https://storage.googleapis.com/kubernetes-release/release/v1.19.4/bin/linux/amd64/kube-controller-manager" \
+  "https://storage.googleapis.com/kubernetes-release/release/v1.19.4/bin/linux/amd64/kube-scheduler" \
+  "https://storage.googleapis.com/kubernetes-release/release/v1.19.4/bin/linux/amd64/kubectl"
 ```
 
 Install the Kubernetes binaries:
@@ -158,7 +158,7 @@ Create the `kube-scheduler.yaml` configuration file:
 
 ```
 cat <<EOF | sudo tee /etc/kubernetes/config/kube-scheduler.yaml
-apiVersion: kubescheduler.config.k8s.io/v1alpha1
+apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: "/var/lib/kubernetes/kube-scheduler.kubeconfig"
@@ -244,6 +244,13 @@ sudo systemctl enable nginx
 ```
 
 ### Verification
+---
+**NOTE**
+
+Although the `kubectl get componentstatues` still "works", the API has been deprecated as of Kubernetes v1.19
+
+[Release Notes](https://kubernetes.io/docs/setup/release/notes/#deprecation-1)
+---
 
 ```
 kubectl get componentstatuses --kubeconfig admin.kubeconfig
@@ -258,7 +265,7 @@ etcd-1               Healthy   {"health":"true"}
 etcd-2               Healthy   {"health":"true"}
 ```
 
-Test the nginx HTTP health check proxy:
+Test the nginx HTTP health check proxy of the kubernetes-api:
 
 ```
 curl -H "Host: kubernetes.default.svc.cluster.local" -i http://127.0.0.1/healthz
@@ -276,6 +283,25 @@ X-Content-Type-Options: nosniff
 
 ok
 ```
+
+Test the health check of the kube-scheduler:
+
+
+```
+curl -i http://127.0.0.1:10251/healthz
+```
+
+```
+HTTP/1.1 200 OK
+Cache-Control: no-cache, private
+Content-Type: text/plain; charset=utf-8
+X-Content-Type-Options: nosniff
+Date: Fri, 27 Nov 2020 17:48:26 GMT
+Content-Length: 2
+
+ok
+```
+
 
 > Remember to run the above commands on each controller node: `controller-0`, `controller-1`, and `controller-2`.
 
@@ -295,7 +321,7 @@ Create the `system:kube-apiserver-to-kubelet` [ClusterRole](https://kubernetes.i
 
 ```
 cat <<EOF | kubectl apply --kubeconfig admin.kubeconfig -f -
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
@@ -323,7 +349,7 @@ Bind the `system:kube-apiserver-to-kubelet` ClusterRole to the `kubernetes` user
 
 ```
 cat <<EOF | kubectl apply --kubeconfig admin.kubeconfig -f -
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:kube-apiserver
@@ -403,12 +429,12 @@ curl --cacert ca.pem https://${KUBERNETES_PUBLIC_ADDRESS}:6443/version
 ```
 {
   "major": "1",
-  "minor": "18",
-  "gitVersion": "v1.18.6",
-  "gitCommit": "dff82dc0de47299ab66c83c626e08b245ab19037",
+  "minor": "19",
+  "gitVersion": "v1.19.4",
+  "gitCommit": "d360454c9bcd1634cf4cc52d1867af5491dc9c5f",
   "gitTreeState": "clean",
-  "buildDate": "2020-07-15T16:51:04Z",
-  "goVersion": "go1.13.9",
+  "buildDate": "2020-11-11T13:09:17Z",
+  "goVersion": "go1.15.2",
   "compiler": "gc",
   "platform": "linux/amd64"
 }

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -249,7 +249,7 @@ sudo systemctl enable nginx
 
 Although the `kubectl get componentstatues` still "works", the API has been deprecated as of Kubernetes v1.19
 
-[Release Notes](https://kubernetes.io/docs/setup/release/notes/#deprecation-1)
+> [Release Notes](https://kubernetes.io/docs/setup/release/notes/#deprecation-1)
 ---
 
 ```

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -49,13 +49,13 @@ sudo swapoff -a
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/crictl-v1.18.0-linux-amd64.tar.gz \
-  https://github.com/opencontainers/runc/releases/download/v1.0.0-rc91/runc.amd64 \
-  https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz \
-  https://github.com/containerd/containerd/releases/download/v1.3.6/containerd-1.3.6-linux-amd64.tar.gz \
-  https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl \
-  https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kube-proxy \
-  https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubelet
+  https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/crictl-v1.19.0-linux-amd64.tar.gz \
+  https://github.com/opencontainers/runc/releases/download/v1.0.0-rc92/runc.amd64 \
+  https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz \
+  https://github.com/containerd/containerd/releases/download/v1.4.2/containerd-1.4.2-linux-amd64.tar.gz \
+  https://storage.googleapis.com/kubernetes-release/release/v1.19.4/bin/linux/amd64/kubectl \
+  https://storage.googleapis.com/kubernetes-release/release/v1.19.4/bin/linux/amd64/kube-proxy \
+  https://storage.googleapis.com/kubernetes-release/release/v1.19.4/bin/linux/amd64/kubelet
 ```
 
 Create the installation directories:
@@ -75,9 +75,9 @@ Install the worker binaries:
 ```
 {
   mkdir containerd
-  tar -xvf crictl-v1.18.0-linux-amd64.tar.gz
-  tar -xvf containerd-1.3.6-linux-amd64.tar.gz -C containerd
-  sudo tar -xvf cni-plugins-linux-amd64-v0.8.6.tgz -C /opt/cni/bin/
+  tar -xvf crictl-v1.19.0-linux-amd64.tar.gz
+  tar -xvf containerd-1.4.2-linux-amd64.tar.gz -C containerd
+  sudo tar -xvf cni-plugins-linux-amd64-v0.8.7.tgz -C /opt/cni/bin/
   sudo mv runc.amd64 runc
   chmod +x crictl kubectl kube-proxy kubelet runc 
   sudo mv crictl kubectl kube-proxy kubelet runc /usr/local/bin/
@@ -304,10 +304,10 @@ gcloud compute ssh controller-0 \
 > output
 
 ```
-NAME       STATUS   ROLES    AGE   VERSION
-worker-0   Ready    <none>   24s   v1.18.6
-worker-1   Ready    <none>   24s   v1.18.6
-worker-2   Ready    <none>   24s   v1.18.6
+NAME       STATUS   ROLES    AGE     VERSION
+worker-0   Ready    <none>   3m      v1.19.4
+worker-1   Ready    <none>   3m      v1.19.4
+worker-2   Ready    <none>   2m58s   v1.19.4
 ```
 
 Next: [Configuring kubectl for Remote Access](10-configuring-kubectl.md)

--- a/docs/10-configuring-kubectl.md
+++ b/docs/10-configuring-kubectl.md
@@ -34,6 +34,12 @@ Generate a kubeconfig file suitable for authenticating as the `admin` user:
 ```
 
 ## Verification
+---
+**NOTE**
+
+Although the `kubectl get componentstatues` still "works", the API has been deprecated as of Kubernetes v1.19
+> [Release Notes](https://kubernetes.io/docs/setup/release/notes/#deprecation-1)
+---
 
 Check the health of the remote Kubernetes cluster:
 
@@ -52,6 +58,7 @@ etcd-1               Healthy   {"health":"true"}
 etcd-2               Healthy   {"health":"true"}
 ```
 
+
 List the nodes in the remote Kubernetes cluster:
 
 ```
@@ -62,9 +69,9 @@ kubectl get nodes
 
 ```
 NAME       STATUS   ROLES    AGE     VERSION
-worker-0   Ready    <none>   2m30s   v1.18.6
-worker-1   Ready    <none>   2m30s   v1.18.6
-worker-2   Ready    <none>   2m30s   v1.18.6
+worker-0   Ready    <none>   6m34s   v1.19.4
+worker-1   Ready    <none>   6m34s   v1.19.4
+worker-2   Ready    <none>   6m32s   v1.19.4
 ```
 
 Next: [Provisioning Pod Network Routes](11-pod-network-routes.md)

--- a/docs/12-dns-addon.md
+++ b/docs/12-dns-addon.md
@@ -7,7 +7,7 @@ In this lab you will deploy the [DNS add-on](https://kubernetes.io/docs/concepts
 Deploy the `coredns` cluster add-on:
 
 ```
-kubectl apply -f https://storage.googleapis.com/kubernetes-the-hard-way/coredns-1.7.0.yaml
+kubectl apply -f https://storage.googleapis.com/kubernetes-the-hard-way/coredns-1.8.0.yaml
 ```
 
 > output

--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -159,7 +159,7 @@ kubectl exec -ti $POD_NAME -- nginx -v
 > output
 
 ```
-nginx version: nginx/1.19.1
+nginx version: nginx/1.19.5
 ```
 
 ## Services


### PR DESCRIPTION
* Updated CoreDNS to 1.8.0
* Updated ETCD to v3.4.14
* K8S  to v.1.19.4
* Updated kube-scheduler to use the v1beta API
* Added curl to kube-scheduler health check endpoint
* Updated crictl to v1.19.0
* Updated runc to v1.0.0-rc91
* Updated CNI plugin to v0.8.7
* Updated output for Nginx output in the smoke test