### PR TITLE
Update NodePort doc link

### DIFF
--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -110,7 +110,7 @@ EOF
 List the etcd cluster members:
 
 ```
-sudo ETCDCTL_API=3 etcdctl member list \
+sudo etcdctl member list \
   --endpoints=https://127.0.0.1:2379 \
   --cacert=/etc/etcd/ca.pem \
   --cert=/etc/etcd/kubernetes.pem \

--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -17,7 +17,7 @@ Print a hexdump of the `kubernetes-the-hard-way` secret stored in etcd:
 
 ```
 gcloud compute ssh controller-0 \
-  --command "sudo ETCDCTL_API=3 etcdctl get \
+  --command "sudo etcdctl get \
   --endpoints=https://127.0.0.1:2379 \
   --cacert=/etc/etcd/ca.pem \
   --cert=/etc/etcd/kubernetes.pem \

--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -166,7 +166,7 @@ nginx version: nginx/1.19.1
 
 In this section you will verify the ability to expose applications using a [Service](https://kubernetes.io/docs/concepts/services-networking/service/).
 
-Expose the `nginx` deployment using a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) service:
+Expose the `nginx` deployment using a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) service:
 
 ```
 kubectl expose deployment nginx --port 80 --type NodePort


### PR DESCRIPTION
Simply updates the link, as "type-" was dropped from the URL.

Also removes the use of the ETCDCTL_API=3 env variable, as API version 3 is the default in current versions of etcdctl and the provided commands run fine without specifying it.