### PR TITLE
Fix spelling; Group nginx install command; Match formatting for "same machine used"

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -208,8 +208,10 @@ A [Google Network Load Balancer](https://cloud.google.com/compute/docs/load-bala
 Install a basic web server to handle HTTP health checks:
 
 ```
-sudo apt-get update
-sudo apt-get install -y nginx
+{
+  sudo apt-get update
+  sudo apt-get install -y nginx
+}
 ```
 
 ```

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -37,7 +37,7 @@ Verify if swap is enabled:
 sudo swapon --show
 ```
 
-If output is empthy then swap is not enabled. If swap is enabled run the following command to disable swap immediately:
+If output is empty then swap is not enabled. If swap is enabled run the following command to disable swap immediately:
 
 ```
 sudo swapoff -a
@@ -292,7 +292,7 @@ EOF
 
 ## Verification
 
-> The compute instances created in this tutorial will not have permission to complete this section. Run the following commands from the same machine used to create the compute instances.
+> The compute instances created in this tutorial will not have permission to complete this section. **Run the following commands from the same machine used to create the compute instances**.
 
 List the registered Kubernetes nodes:
 


### PR DESCRIPTION
Nice tutorial, very helpful! Just a few things I noticed as I went through it and submitting fixes for them.

 - Group nginx install commands (already common throughout).
 - Spelling on word `empty`.
 - Other two notes about `Run the following commands from the same machine used to create the compute instances` had strong text formatting, so added to the third one.