### PR TITLE
need to reboot cluster controller VMs to sync etcd configuration

### DIFF
--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -107,7 +107,7 @@ EOF
 
 ## Verification
 
-List the etcd cluster members:
+Reboot the controller nodes, and then SSH into one of the nodes. List the etcd cluster members:
 
 ```
 sudo ETCDCTL_API=3 etcdctl member list \


### PR DESCRIPTION
Hi, I got stuck on 07-bootstrapping-etcd.md and needed to reboot the machines to pick up the etcd configuration. I spent an hour or three going over my config and in the end all I needed to do was reboot the controllers to complete the etcd config.

before rebooting the controllers, I got this error: 

```
aireilly@controller-0:~$ sudo ETCDCTL_API=3 etcdctl member list \
>   --endpoints=https://127.0.0.1:2379 \
>   --cacert=/etc/etcd/ca.pem \
>   --cert=/etc/etcd/kubernetes.pem \
>   --key=/etc/etcd/kubernetes-key.pem
{"level":"warn","ts":"2021-03-31T21:11:23.008Z","caller":"clientv3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"endpoint://client-0db00acd-e8b2-44ba-a9fe-4df860eb1456/127.0.0.1:2379","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = latest balancer error: all SubConns are in TransientFailure, latest connection error: connection error: desc = \"transport: authentication handshake failed: remote error: tls: bad certificate\""}
Error: context deadline exceeded
```

After rebooting the controller nodes, I got a successul connection: 

```
aireilly@controller-0:~$ sudo ETCDCTL_API=3 etcdctl member list \
>   --endpoints=https://127.0.0.1:2379 \
>   --cacert=/etc/etcd/ca.pem \
>   --cert=/etc/etcd/kubernetes.pem \
>   --key=/etc/etcd/kubernetes-key.pem
3a57933972cb5131, started, controller-2, https://10.240.0.12:2380, https://10.240.0.12:2379, false
f98dc20bce6225a0, started, controller-0, https://10.240.0.10:2380, https://10.240.0.10:2379, false
ffed16798470cab5, started, controller-1, https://10.240.0.11:2380, https://10.240.0.11:2379, false
```

