### PR TITLE
Removed duplicate deletion block

### DIFF
--- a/docs/14-cleanup.md
+++ b/docs/14-cleanup.md
@@ -54,10 +54,3 @@ Delete the `kubernetes-the-hard-way` network VPC:
   gcloud -q compute networks delete kubernetes-the-hard-way
 }
 ```
-
-Delete the `kubernetes-the-hard-way` compute address:
-
-```
-gcloud -q compute addresses delete kubernetes-the-hard-way \
-  --region $(gcloud config get-value compute/region)
-```


### PR DESCRIPTION
The static IP address is already getting deleted at line number 29. So, this deleted block was causing an error and was redundant.