### PR TITLE
Utilize the absolute path to the ca.pem file

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -404,7 +404,7 @@ KUBERNETES_PUBLIC_ADDRESS=$(gcloud compute addresses describe kubernetes-the-har
 Make a HTTP request for the Kubernetes version info:
 
 ```
-curl --cacert ca.pem https://${KUBERNETES_PUBLIC_ADDRESS}:6443/version
+curl --cacert /var/lib/kubernetes/ca.pem https://${KUBERNETES_PUBLIC_ADDRESS}:6443/version
 ```
 
 > output


### PR DESCRIPTION
On the `Configure the Kubernetes API Server` step, we're moving the file to the `/var/lib/kubernetes/` directory. Now when we try to verify the Kubernetes version info utilizing the cert, we'll receive the following error:


```
curl --cacert ca.pem https://${KUBERNETES_PUBLIC_ADDRESS}:6443/version
curl: (77) error setting certificate verify locations:
  CAfile: ca.pem
  CApath: /etc/ssl/certs
```