### PR TITLE
fix typo in 09-bootstrapping-kubernetes-workers.md

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -37,7 +37,7 @@ Verify if swap is enabled:
 sudo swapon --show
 ```
 
-If output is empthy then swap is not enabled. If swap is enabled run the following command to disable swap immediately:
+If output is empty then swap is not enabled. If swap is enabled run the following command to disable swap immediately:
 
 ```
 sudo swapoff -a


### PR DESCRIPTION
Just saw this during a run. Thanks for this great repo. 🚀
empthy -> empty