### PR TITLE
Updated pricing estimate link to include 200GiB boot disks for compute instances. Updated text to reflect cost of disk space, plus approximately doubled cost of other compute resources used in this tutorial.

### DIFF
--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -4,7 +4,7 @@
 
 This tutorial leverages the [Google Cloud Platform](https://cloud.google.com/) to streamline provisioning of the compute infrastructure required to bootstrap a Kubernetes cluster from the ground up. [Sign up](https://cloud.google.com/free/) for $300 in free credits.
 
-[Estimated cost](https://cloud.google.com/products/calculator#id=873932bc-0840-4176-b0fa-a8cfd4ca61ae) to run this tutorial: $0.23 per hour ($5.50 per day).
+[Estimated cost](https://cloud.google.com/products/calculator#id=7f37dfb3-b201-4283-acc8-d751540ab41d) to run this tutorial: $0.49 per hour ($11.83 per day).
 
 > The compute resources required for this tutorial exceed the Google Cloud Platform free tier.
 


### PR DESCRIPTION
The cost estimate currently in this document is both out of date, and missing the cost of the 200GB of disk space being provisioned for the compute instances. The updated estimate is more than double what is currently stated on this page. This is a significant difference that is likely to matter to people following this guide.

Note: The calculator works in terms of GiB, but the gcloud commands shown provision in terms of GB. To err on the side of caution, I used 200GiB in the calculation, rather than converting to ~186GiB.