### PR TITLE
Update 01-prerequisites.md

### DIFF
--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -48,6 +48,13 @@ Set a default compute zone:
 gcloud config set compute/zone us-west1-c
 ```
 
+Set the default compute region and compute zone on the project itself:
+
+```
+gcloud compute project-info add-metadata \
+    --metadata google-compute-default-region=us-west1,google-compute-default-zone=us-west1-c
+```
+
 > Use the `gcloud compute zones list` command to view additional regions and zones.
 
 ## Running Commands in Parallel with tmux


### PR DESCRIPTION
On newly created GCP projects, default region and zone are not set, leading to `REGION=$(curl -s -H "Metadata-Flavor: Google" \
  http://metadata.google.internal/computeMetadata/v1/project/attributes/google-compute-default-region)` failing with a 404 in section [08-bootstrapping-kubernetes-controllers](https://github.com/kelseyhightower/kubernetes-the-hard-way/blob/master/docs/08-bootstrapping-kubernetes-controllers.md#configure-the-kubernetes-api-server)