### PR TITLE
Automated spellcheck via GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Documentation Checks
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "docs/**/*"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "docs/**/*"
+jobs:
+  spellcheck:
+    name: "Docs: Spellcheck"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        name: Check out the code
+      - uses: actions/setup-node@v1
+        name: Setup node
+        with:
+          node-version: "16"
+      - run: npm install -g cspell
+        name: Install cSpell
+      - run: cspell --config ./cSpell.json "docs/**/*.md" --no-progress
+        name: Run cSpell

--- a/cSpell.json
+++ b/cSpell.json
@@ -1,0 +1,62 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "words": [
+  ],
+  "ignoreWords": [
+  ],
+  "patterns": [
+    {
+      "name": "Markdown links",
+      "pattern": "\\((.*)\\)",
+      "description": ""
+    },
+    {
+      "name": "Markdown code blocks",
+      "pattern": "/^(\\s*`{3,}).*[\\s\\S]*?^\\1/gmx",
+      "description": "Taken from the cSpell example at https://cspell.org/configuration/patterns/#verbose-regular-expressions"
+    },
+    {
+      "name": "Inline code blocks",
+      "pattern": "\\`([^\\`\\r\\n]+?)\\`",
+      "description": "https://stackoverflow.com/questions/41274241/how-to-capture-inline-markdown-code-but-not-a-markdown-code-fence-with-regex"
+    },
+    {
+      "name": "Link contents",
+      "pattern": "\\<a(.*)\\>",
+      "description": ""
+    },
+    {
+      "name": "Snippet references",
+      "pattern": "-- snippet:(.*)",
+      "description": ""
+    },
+    {
+      "name": "Snippet references 2",
+      "pattern": "\\<\\[sample:(.*)",
+      "description": "another kind of snippet reference"
+    },
+    {
+      "name": "Multi-line code blocks",
+      "pattern": "/^\\s*```[\\s\\S]*?^\\s*```/gm"
+    },
+    {
+      "name": "HTML Tags",
+      "pattern": "<[^>]*>",
+      "description": "Reference: https://stackoverflow.com/questions/11229831/regular-expression-to-remove-html-tags-from-a-string"
+    }
+  ],
+  "ignoreRegExpList": [
+    "Markdown links",
+    "Markdown code blocks",
+    "Inline code blocks",
+    "Link contents",
+    "Snippet references",
+    "Snippet references 2",
+    "Multi-line code blocks",
+    "HTML Tags"
+  ],
+  "ignorePaths": [
+    
+  ]
+}

--- a/cSpell.json
+++ b/cSpell.json
@@ -2,9 +2,12 @@
   "version": "0.2",
   "language": "en",
   "words": [
+    "CFSSL",
+    "kubeconfig",
+    "kubeconfigs",
+    "runc"
   ],
-  "ignoreWords": [
-  ],
+  "ignoreWords": [],
   "patterns": [
     {
       "name": "Markdown links",
@@ -56,7 +59,5 @@
     "Multi-line code blocks",
     "HTML Tags"
   ],
-  "ignorePaths": [
-    
-  ]
+  "ignorePaths": []
 }

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -1,6 +1,6 @@
 # Provisioning a CA and Generating TLS Certificates
 
-In this lab you will provision a [PKI Infrastructure](https://en.wikipedia.org/wiki/Public_key_infrastructure) using CloudFlare's PKI toolkit, [cfssl](https://github.com/cloudflare/cfssl), then use it to bootstrap a Certificate Authority, and generate TLS certificates for the following components: etcd, kube-apiserver, kube-controller-manager, kube-scheduler, kubelet, and kube-proxy.
+In this lab you will provision a [PKI Infrastructure](https://en.wikipedia.org/wiki/Public_key_infrastructure) using CloudFlare's PKI toolkit, [cfssl](https://github.com/cloudflare/cfssl), then use it to bootstrap a Certificate Authority, and generate TLS certificates for the following components: `etcd`, `kube-apiserver`, `kube-controller-manager`, `kube-scheduler`, `kubelet`, and `kube-proxy`.
 
 ## Certificate Authority
 
@@ -202,7 +202,6 @@ kube-controller-manager-key.pem
 kube-controller-manager.pem
 ```
 
-
 ### The Kube Proxy Client Certificate
 
 Generate the `kube-proxy` client certificate and private key:
@@ -288,7 +287,6 @@ Results:
 kube-scheduler-key.pem
 kube-scheduler.pem
 ```
-
 
 ### The Kubernetes API Server Certificate
 
@@ -388,7 +386,6 @@ Results:
 service-account-key.pem
 service-account.pem
 ```
-
 
 ## Distribute the Client and Server Certificates
 


### PR DESCRIPTION
I've made this change for a few repositories recently (NUnit, Marten, HotChocolate, Uno Platform, Playwright, etc.). I was going through my starred repositories, and you're a phenomenal leader in the community, so I figured you might benefit from this too.

* Adds GitHub action to run cSpell
* Adds a cSpell configuration file
* Addresses the errors the cSpell finds. 
  * In most cases that means adding terms to the dictionary or adding back-ticks around terms that aren't necessarily meant to be words.

I figured it might be valuable especially as you consider additional contributions. If not, I won't be offended if you close it. :)