### PR TITLE
Update 12-dns-addon.md

### DIFF
--- a/docs/12-dns-addon.md
+++ b/docs/12-dns-addon.md
@@ -7,7 +7,7 @@ In this lab you will deploy the [DNS add-on](https://kubernetes.io/docs/concepts
 Deploy the `coredns` cluster add-on:
 
 ```
-kubectl apply -f https://storage.googleapis.com/kubernetes-the-hard-way/coredns-1.8.yaml
+kubectl apply -f https://raw.githubusercontent.com/kelseyhightower/kubernetes-the-hard-way/master/deployments/coredns-1.7.0.yaml
 ```
 
 > output


### PR DESCRIPTION
Existing file path for `coredns` didn't exist, this uses the one in the actual repository for reliability