### PR TITLE
Update broken manage service accounts link

### DIFF
--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -346,7 +346,7 @@ kubernetes.pem
 
 ## The Service Account Key Pair
 
-The Kubernetes Controller Manager leverages a key pair to generate and sign service account tokens as described in the [managing service accounts](https://kubernetes.io/docs/admin/service-accounts-admin/) documentation.
+The Kubernetes Controller Manager leverages a key pair to generate and sign service account tokens as described in the [managing service accounts](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/) documentation.
 
 Generate the `service-account` certificate and private key:
 


### PR DESCRIPTION
## What this PR does?

This PR simply fixes a broken link. More detailed the `managing service accounts` link points to https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/ currently gives a 404. As a result it is replaced by the https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/ link which is working.

## Issues related to this PR?
N/A
