### PR TITLE
updated jumpbox initial set up installation

### DIFF
--- a/docs/02-jumpbox.md
+++ b/docs/02-jumpbox.md
@@ -17,6 +17,7 @@ All commands will be run as the `root` user. This is being done for the sake of 
 Now that you are logged into the `jumpbox` machine as the `root` user, you will install the command line utilities that will be used to preform various tasks throughout the tutorial. 
 
 ```bash
+apt update
 apt-get -y install wget curl vim openssl git
 ```
 


### PR DESCRIPTION
If you straight up tried to installed the required tools, you'd get an error, so you need to update the apt repository first.
![error-output-and-fix](https://github.com/kelseyhightower/kubernetes-the-hard-way/assets/85107972/bf7a1a67-762a-4f5d-b6c2-4adf37c2333b)
