### PR TITLE
Error: mkdir: cannot create directory ‘/var/lib/kubelet’

### DIFF
--- a/docs/05-kubernetes-configuration-files.md
+++ b/docs/05-kubernetes-configuration-files.md
@@ -188,7 +188,7 @@ Copy the `kubelet` and `kube-proxy` kubeconfig files to the node-0 instance:
 
 ```bash
 for host in node-0 node-1; do
-  ssh root@$host "mkdir /var/lib/{kube-proxy,kubelet}"
+  ssh root@$host "mkdir /var/lib/kube-proxy"
   
   scp kube-proxy.kubeconfig \
     root@$host:/var/lib/kube-proxy/kubeconfig \

--- a/docs/05-kubernetes-configuration-files.md
+++ b/docs/05-kubernetes-configuration-files.md
@@ -188,7 +188,7 @@ Copy the `kubelet` and `kube-proxy` kubeconfig files to the node-0 instance:
 
 ```bash
 for host in node-0 node-1; do
-  ssh root@$host "mkdir /var/lib/kube-proxy"
+  ssh root@$host "mkdir -p /var/lib/{kube-proxy,kubelet}"
   
   scp kube-proxy.kubeconfig \
     root@$host:/var/lib/kube-proxy/kubeconfig \


### PR DESCRIPTION
Error:
mkdir: cannot create directory ‘/var/lib/kubelet’

It has been created in the previous section:
https://github.com/kelseyhightower/kubernetes-the-hard-way/blob/master/docs/04-certificate-authority.md#distribute-the-client-and-server-certificates