### PR TITLE
Fix a bug while setting the hostname for all machines

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -104,8 +104,8 @@ To configure the hostname for each machine, run the following commands on the `j
 Set the hostname on each machine listed in the `machines.txt` file:
 
 ```bash
-while read IP FQDN HOST SUBNET; do 
-    CMD="sed -i 's/^127.0.1.1.*/127.0.1.1\t${FQDN} ${HOST}/' /etc/hosts"
+while read IP FQDN HOST SUBNET; do
+    CMD="sed -i 's/^127.0.0.1.*/127.0.0.1\t${FQDN} ${HOST}/' /etc/hosts"
     ssh -n root@${IP} "$CMD"
     ssh -n root@${IP} hostnamectl hostname ${HOST}
 done < machines.txt


### PR DESCRIPTION
Fixes the sed command that adds a line to the /etc/hosts to change the hostname and the fully qualified name file for each machine.

Discovered it because the output of this command is different
https://github.com/kelseyhightower/kubernetes-the-hard-way/blob/a9cb5f7ba50b3ed496a18a09c273941f80c6375a/docs/03-compute-resources.md?plain=1#L116-L125