### PR TITLE
fixed a script issue in document 3-compute-resources

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -107,7 +107,7 @@ Set the hostname on each machine listed in the `machines.txt` file:
 while read IP FQDN HOST SUBNET; do 
     CMD="sed -i 's/^127.0.1.1.*/127.0.1.1\t${FQDN} ${HOST}/' /etc/hosts"
     ssh -n root@${IP} "$CMD"
-    ssh -n root@${IP} hostnamectl hostname ${HOST}
+    ssh -n root@${IP} hostnamectl set-hostname ${HOST}
 done < machines.txt
 ```
 


### PR DESCRIPTION
It looks like there was a mistake in the document "docs/03-compute-resources.md"

the command was 
`ssh -n root@${IP} hostnamectl hostname ${HOST}`

it should be
`ssh -n root@${IP} hostnamectl set-hostname ${HOST}`

as set-hostname is the correct flag.

and running with old command will give following error

`
Unknown operation hostname`