### PR TITLE
Update kube-apiserver.service to remove --apiserver-count flag

### DIFF
--- a/units/kube-apiserver.service
+++ b/units/kube-apiserver.service
@@ -5,7 +5,6 @@ Documentation=https://github.com/kubernetes/kubernetes
 [Service]
 ExecStart=/usr/local/bin/kube-apiserver \
   --allow-privileged=true \
-  --apiserver-count=1 \
   --audit-log-maxage=30 \
   --audit-log-maxbackup=3 \
   --audit-log-maxsize=100 \


### PR DESCRIPTION
As of at least Kubernetes v1.28.3 (perhaps older) the --apiserver-count is no longer documented in the [api server flags](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) list.  It's presence in the `/etc/systemd/system/kube-apiserver.service` file prevents the API server from starting properly.