### PR TITLE
Update 09-bootstrapping-kubernetes-workers.md

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -32,7 +32,6 @@ for host in node-0 node-1; do
     downloads/kube-proxy \
     configs/99-loopback.conf \
     configs/containerd-config.toml \
-    configs/kubelet-config.yaml \
     configs/kube-proxy-config.yaml \
     units/containerd.service \
     units/kubelet.service \


### PR DESCRIPTION
removed configs/kubelet-config.yaml \ from the scp command, because it will overwrite the configured kubelet-config.yaml file (has the pods SUBNETs) with the default one