### PR TITLE
fix(smoke-test): dynamically fetch node name for service curl test

### DIFF
--- a/docs/12-smoke-test.md
+++ b/docs/12-smoke-test.md
@@ -168,11 +168,16 @@ Retrieve the node port assigned to the `nginx` service:
 NODE_PORT=$(kubectl get svc nginx \
   --output=jsonpath='{range .spec.ports[0]}{.nodePort}')
 ```
+Identify the node where the nginx pod is scheduled:
+
+```bash
+NODE_NAME=$(kubectl get pod -l app=nginx -o jsonpath='{.items[0].spec.nodeName}')
+```
 
 Make an HTTP request using the IP address and the `nginx` node port:
 
 ```bash
-curl -I http://node-0:${NODE_PORT}
+curl -I http://${NODE_NAME}:${NODE_PORT}
 ```
 
 ```text


### PR DESCRIPTION
Previously, the smoke test assumed the nginx pod would always be scheduled on `node-0`, which could lead to failures if the pod was placed on a different node. This update fixes that by dynamically fetching the node where the pod is running.

Changes:
Updated the smoke test to retrieve the correct node name for the curl request instead of assuming `node-0`.