### PR TITLE
Re-add encryption-config.yaml

### DIFF
--- a/configs/encryption-config.yaml
+++ b/configs/encryption-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+      - secrets
+    providers:
+      - aescbc:
+          keys:
+            - name: key
+              secret: ${ENCRYPTION_KEY}
+      - identity: {}


### PR DESCRIPTION
The encryption config referenced at https://github.com/kelseyhightower/kubernetes-the-hard-way/blob/master/docs/06-data-encryption-keys.md does not exist and appears to have been deleted, this PR re-adds it.