### PR TITLE
[Update] auto allocate pod subnet for each node

### DIFF
--- a/units/kube-controller-manager.service
+++ b/units/kube-controller-manager.service
@@ -6,6 +6,7 @@ Documentation=https://github.com/kubernetes/kubernetes
 ExecStart=/usr/local/bin/kube-controller-manager \
   --bind-address=0.0.0.0 \
   --cluster-cidr=10.200.0.0/16 \
+  --allocate-node-cidrs=true \
   --cluster-name=kubernetes \
   --cluster-signing-cert-file=/var/lib/kubernetes/ca.crt \
   --cluster-signing-key-file=/var/lib/kubernetes/ca.key \


### PR DESCRIPTION
I implemented my Kubernetes cluster using this repository. This is an amazing and helpful guide. However, when I installed the Flannel CNI plugin for my cluster, I encountered the error: `Error registering network: failed to acquire lease: node "node-1" pod cidr not assigned`.

To resolve this, I added the `--allocate-node-cidrs=true` option to the kube-controller-manager.service to automatically allocate subnet IP ranges for the nodes. This is helpful for installing CNI plugins later.