### PR TITLE
Fix uncommented PermitRootLogin in /etc/ssh/sshd_config

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -44,7 +44,7 @@ Edit the `/etc/ssh/sshd_config` SSH daemon configuration file and set the `Permi
 
 ```bash
 sed -i \
-  's/^#PermitRootLogin.*/PermitRootLogin yes/' \
+  's/^#*PermitRootLogin.*/PermitRootLogin yes/' \
   /etc/ssh/sshd_config
 ```
 


### PR DESCRIPTION
In some Debian distributives (i.e. Debian 12 standard bookworm image used in GCP) `PermitRootLogin` is already uncommented; the regex in the exercise would skip it. The suggested change will act upon either uncommented line or commented.