### PR TITLE
Add kernel dependency kmod

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -54,7 +54,7 @@ Install the OS dependencies:
 ```bash
 {
   apt-get update
-  apt-get -y install socat conntrack ipset
+  apt-get -y install socat conntrack ipset kmod
 }
 ```
 


### PR DESCRIPTION
In the containerd service, the ```ExecStartPre=/sbin/modprobe overlay``` command ensures that the overlay module is loaded before the service starts. However, on some distributions, this module might not be available by default and may need to be installed manually. This update addresses potential compatibility issues across various environments.