### PR TITLE
Fix: typo

### DIFF
--- a/docs/02-jumpbox.md
+++ b/docs/02-jumpbox.md
@@ -88,7 +88,7 @@ total 510M
 
 ### Install kubectl
 
-In this section you will install the `kubectl`, the official Kubernetes client command line tool, on the `jumpbox` machine. `kubectl will be used to interact with the Kubernetes control once your cluster is provisioned later in this tutorial.
+In this section you will install the `kubectl`, the official Kubernetes client command line tool, on the `jumpbox` machine. `kubectl` will be used to interact with the Kubernetes control once your cluster is provisioned later in this tutorial.
 
 Use the `chmod` command to make the `kubectl` binary executable and move it to the `/usr/local/bin/` directory:
 


### PR DESCRIPTION
Add a missing backtick after `kubectl` command

Thank you for this awesome repo! I'm preparing for the CKA and will give this a shot soon, I am sure it will be of great help! :)
While reading the docs I noticed this small typo which triggered my OCD