### PR TITLE
Fix links

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -160,7 +160,7 @@ At this point the Kubernetes control plane is up and running. Run the following 
 Make a HTTP request for the Kubernetes version info:
 
 ```bash
-curl -k --cacert ca.crt https://server.kubernetes.local:6443/version
+curl -k https://server.kubernetes.local:6443/version
 ```
 
 ```text

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -138,7 +138,7 @@ Kubernetes control plane is running at https://127.0.0.1:6443
 
 In this section you will configure RBAC permissions to allow the Kubernetes API Server to access the Kubelet API on each worker node. Access to the Kubelet API is required for retrieving metrics, logs, and executing commands in pods.
 
-> This tutorial sets the Kubelet `--authorization-mode` flag to `Webhook`. Webhook mode uses the [SubjectAccessReview](https://kubernetes.io/docs/admin/authorization/#checking-api-access) API to determine authorization.
+> This tutorial sets the Kubelet `--authorization-mode` flag to `Webhook`. Webhook mode uses the [SubjectAccessReview](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#checking-api-access) API to determine authorization.
 
 The commands in this section will affect the entire cluster and only need to be run on the controller node.
 
@@ -146,7 +146,7 @@ The commands in this section will affect the entire cluster and only need to be 
 ssh root@server
 ```
 
-Create the `system:kube-apiserver-to-kubelet` [ClusterRole](https://kubernetes.io/docs/admin/authorization/rbac/#role-and-clusterrole) with permissions to access the Kubelet API and perform most common tasks associated with managing pods:
+Create the `system:kube-apiserver-to-kubelet` [ClusterRole](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) with permissions to access the Kubelet API and perform most common tasks associated with managing pods:
 
 ```bash
 kubectl apply -f kube-apiserver-to-kubelet.yaml \

--- a/docs/10-configuring-kubectl.md
+++ b/docs/10-configuring-kubectl.md
@@ -11,8 +11,7 @@ Each kubeconfig requires a Kubernetes API Server to connect to.
 You should be able to ping `server.kubernetes.local` based on the `/etc/hosts` DNS entry from a previous lap.
 
 ```bash
-curl -k --cacert ca.crt \
-  https://server.kubernetes.local:6443/version
+curl -k https://server.kubernetes.local:6443/version
 ```
 
 ```text


### PR DESCRIPTION
1. Fixed links to documentation.
2. Removed `--cacert` in the curl example, it makes no sense with `-k`.