### PR TITLE
Deploy tutorial as static MkDocs site to GitHub pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: build
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+
+
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs
+      - run: pip install mkdocs-material 
+      - run: pip install mkdocs-literate-nav
+      - run: pip install mkdocs-autorefs
+      - run: mkdocs gh-deploy --force --clean --verbose

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,29 @@
+# Introduction
+
+This tutorial walks you through setting up Kubernetes the hard way. This guide is not for someone looking for a fully automated tool to bring up a Kubernetes cluster. Kubernetes The Hard Way is optimized for learning, which means taking the long route to ensure you understand each task required to bootstrap a Kubernetes cluster.
+
+> The results of this tutorial should not be viewed as production ready, and may receive limited support from the community, but don't let that stop you from learning!
+
+## Copyright
+
+<a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.
+
+
+## Target Audience
+
+The target audience for this tutorial is someone who wants to understand the fundamentals of Kubernetes and how the core components fit together.
+
+## Cluster Details
+
+Kubernetes The Hard Way guides you through bootstrapping a basic Kubernetes cluster with all control plane components running on a single node, and two worker nodes, which is enough to learn the core concepts.
+
+Component versions:
+
+* [kubernetes](https://github.com/kubernetes/kubernetes) v1.28.x
+* [containerd](https://github.com/containerd/containerd) v1.7.x
+* [cni](https://github.com/containernetworking/cni) v1.3.x
+* [etcd](https://github.com/etcd-io/etcd) v3.4.x
+
+## Labs
+
+This tutorial requires four (4) ARM64 based virtual or physical machines connected to the same network. While ARM64 based machines are used for the tutorial, the lessons learned can be applied to other platforms.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,67 @@
+site_name: Kubernetes The Hard Way
+docs_dir: docs
+site_dir: site
+repo_url: https://github.com/kelseyhightower/kubernetes-the-hard-way
+edit_uri: edit/master/docs/
+
+theme:
+  name: material
+  features:
+    - content.action.edit
+    - navigation.footer
+    - content.code.copy
+    - navigation.indexes
+    - announce.dismiss
+    - navigation.path
+    - toc.integrate
+    - navigation.sections
+    - search.highlight
+    - search.share
+    - content.tooltips
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      font: false
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      font: false
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - md_in_html
+  - tables
+  - toc:
+      permalink: 🔗
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.details
+  - pymdownx.tasklist:
+      custom_checkbox: true
+
+plugins:
+  #- tags:
+  #    tags_file: tags.md
+  - search
+  - autorefs
+  - literate-nav:
+     nav_file: README.md
+     implicit_index: true


### PR DESCRIPTION
Add GitHub pages workflows to generate and deploy the tutorial as a static MkDocs site on GitHub pages.

The site is generated from the current markdown files and has
* Previous and Next buttons in the footer
* a simple side navigation
* a powerful search from MkDocs using the MkDocs theme materials.
* link to GitHub edit page from the individual pages
    *  add buttons to jump quickly to GitHub for editing the page at hand
* workflow for building and deploying the site to the gh_pages branch directly after merge to master which is then pushed to the GitHub pages site as static site.
 
We can afterwards remove the "Next" links at the end of each file as this is obsolete with the Next button.

Demo: https://karneades.github.io/kubernetes-the-hard-way/

Closes https://github.com/kelseyhightower/kubernetes-the-hard-way/issues/819