### PR TITLE
fix: Remove redundant kubelet-config.yaml copy in node setup script

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -32,7 +32,6 @@ for host in node-0 node-1; do
     downloads/kube-proxy \
     configs/99-loopback.conf \
     configs/containerd-config.toml \
-    configs/kubelet-config.yaml \
     configs/kube-proxy-config.yaml \
     units/containerd.service \
     units/kubelet.service \


### PR DESCRIPTION
The first code block in the node setup script already correctly modifies and copies the `kubelet-config.yaml` file to each worker node, replacing the "SUBNET" placeholder with the appropriate subnet.

The second code block was redundantly copying the original, unmodified `kubelet-config.yaml` file, overwriting the correctly modified version.