### PR TITLE
Fixing Smoke Test curl command

### DIFF
--- a/docs/12-smoke-test.md
+++ b/docs/12-smoke-test.md
@@ -168,12 +168,17 @@ NODE_PORT=$(kubectl get svc nginx \
   --output=jsonpath='{range .spec.ports[0]}{.nodePort}')
 ```
 
+Retrieve the hostname of the node on which the `nginx` pod is running on:
 
+```bash
+NODE_HOST=$(kubectl get pods -l app=nginx \
+  -o jsonpath="{.items[0].spec.nodeName}")
+```
 
 Make an HTTP request using the IP address and the `nginx` node port:
 
 ```bash
-curl -I http://node-0:${NODE_PORT}
+curl -I http://${NODE_HOST}:${NODE_PORT}
 ```
 
 ```text


### PR DESCRIPTION
Fixing the documentation to cater to the possibility that the nginx pod is not running on node-0.
I had tripped up on this section because the nginx pod on my environment was running on node-1 instead.