### PR TITLE
fix: use FQDN instead of HOST

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -107,7 +107,7 @@ Set the hostname on each machine listed in the `machines.txt` file:
 while read IP FQDN HOST SUBNET; do 
     CMD="sed -i 's/^127.0.1.1.*/127.0.1.1\t${FQDN} ${HOST}/' /etc/hosts"
     ssh -n root@${IP} "$CMD"
-    ssh -n root@${IP} hostnamectl hostname ${HOST}
+    ssh -n root@${IP} hostnamectl hostname ${FQDN}
 done < machines.txt
 ```
 


### PR DESCRIPTION
Hey, when we use the HOST, we would end up with 
```
server
node-0
node-1
```

instead of
```
server.kubernetes.local
node-0.kubernetes.local
node-1.kubernetes.local
```