### PR TITLE
removed SUBNET replacement for kubelet-config.yaml

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -14,9 +14,6 @@ for HOST in node-0 node-1; do
   sed "s|SUBNET|$SUBNET|g" \
     configs/10-bridge.conf > 10-bridge.conf
 
-  sed "s|SUBNET|$SUBNET|g" \
-    configs/kubelet-config.yaml > kubelet-config.yaml
-
   scp 10-bridge.conf kubelet-config.yaml \
   root@${HOST}:~/
 done

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -14,7 +14,7 @@ for HOST in node-0 node-1; do
   sed "s|SUBNET|$SUBNET|g" \
     configs/10-bridge.conf > 10-bridge.conf
 
-  scp 10-bridge.conf kubelet-config.yaml \
+  scp 10-bridge.conf configs/kubelet-config.yaml \
   root@${HOST}:~/
 done
 ```


### PR DESCRIPTION
removed SUBNET replacement for kubelet-config.yaml in 09-bootstrapping-kubernetes-workers.md

kubelet-config.yaml does not contain liternal text "SUBNET"