### PR TITLE
Minor fixes (broken links, typo, unnecessary `sed` command)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ service-account.pem
 service-account-csr.json
 *.swp
 .idea/
+.DS_Store

--- a/ca.conf
+++ b/ca.conf
@@ -26,7 +26,7 @@ O  = system:masters
 #
 # The Kubernetes Controller Manager leverages a key pair to generate
 # and sign service account tokens as described in the
-# [managing service accounts](https://kubernetes.io/docs/admin/service-accounts-admin/)
+# [managing service accounts](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/
 # documentation.
 
 [service-accounts]

--- a/ca.conf
+++ b/ca.conf
@@ -39,9 +39,9 @@ CN = service-accounts
 
 # Worker Nodes
 #
-# Kubernetes uses a [special-purpose authorization mode](https://kubernetes.io/docs/admin/authorization/node/)
+# Kubernetes uses a [special-purpose authorization mode](https://kubernetes.io/docs/reference/access-authn-authz/node/)
 # called Node Authorizer, that specifically authorizes API requests made
-# by [Kubelets](https://kubernetes.io/docs/concepts/overview/components/#kubelet).
+# by [Kubelets](https://kubernetes.io/docs/concepts/architecture/#kubelet).
 # In order to be authorized by the Node Authorizer, Kubelets must use a credential
 # that identifies them as being in the `system:nodes` group, with a username
 # of `system:node:<nodeName>`.

--- a/docs/02-jumpbox.md
+++ b/docs/02-jumpbox.md
@@ -14,7 +14,7 @@ All commands will be run as the `root` user. This is being done for the sake of 
 
 ### Install Command Line Utilities
 
-Now that you are logged into the `jumpbox` machine as the `root` user, you will install the command line utilities that will be used to preform various tasks throughout the tutorial.
+Now that you are logged into the `jumpbox` machine as the `root` user, you will install the command line utilities that will be used to perform various tasks throughout the tutorial.
 
 ```bash
 {

--- a/docs/06-data-encryption-keys.md
+++ b/docs/06-data-encryption-keys.md
@@ -21,7 +21,7 @@ envsubst < configs/encryption-config.yaml \
   > encryption-config.yaml
 ```
 
-Copy the `encryption-config.yaml` encryption config file to each controller instance:
+Copy the `encryption-config.yaml` encryption config file to the server instance:
 
 ```bash
 scp encryption-config.yaml root@server:~/

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -14,9 +14,6 @@ for HOST in node-0 node-1; do
   sed "s|SUBNET|$SUBNET|g" \
     configs/10-bridge.conf > 10-bridge.conf
 
-  sed "s|SUBNET|$SUBNET|g" \
-    configs/kubelet-config.yaml > kubelet-config.yaml
-
   scp 10-bridge.conf kubelet-config.yaml \
   root@${HOST}:~/
 done


### PR DESCRIPTION
Thanks for the excellent tutorial. As I was going through it again, I noticed a few minor things that should be cleaned up. The `sed` command removal is part of #868, too.