### PR TITLE
Add another api-server IP to SAN list.

### DIFF
--- a/ca.conf
+++ b/ca.conf
@@ -182,6 +182,7 @@ subjectKeyIdentifier = hash
 [kube-api-server_alt_names]
 IP.0  = 127.0.0.1
 IP.1  = 10.32.0.1
+IP.2  = 10.0.0.1
 DNS.0 = kubernetes
 DNS.1 = kubernetes.default
 DNS.2 = kubernetes.default.svc


### PR DESCRIPTION
API server also uses an IP address 10.0.0.1 . When this address is missing in the API server certificate, calls to this IP will fail to do the TLS handshake