### PR TITLE
remove certs copy cmd in etcd bootstrap lab and optimize the SUBNET retrieval logic to avoid errors

### DIFF
--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -38,8 +38,6 @@ Extract and install the `etcd` server and the `etcdctl` command line utility:
 {
   mkdir -p /etc/etcd /var/lib/etcd
   chmod 700 /var/lib/etcd
-  cp ca.crt kube-api-server.key kube-api-server.crt \
-    /etc/etcd/
 }
 ```
 

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -10,7 +10,7 @@ Copy the Kubernetes binaries and systemd unit files to each worker instance:
 
 ```bash
 for HOST in node-0 node-1; do
-  SUBNET=$(grep ${HOST} machines.txt | cut -d " " -f 4)
+  SUBNET=$(grep "${HOST}" machines.txt | awk '{print $4}')
   sed "s|SUBNET|$SUBNET|g" \
     configs/10-bridge.conf > 10-bridge.conf
 


### PR DESCRIPTION
no need to copy certs for a single etcd without TLS
1. clean code no need
2. Optimize the SUBNET retrieval logic to avoid errors