### PR TITLE
add-service-ip-range

### DIFF
--- a/units/kube-apiserver.service
+++ b/units/kube-apiserver.service
@@ -26,6 +26,7 @@ ExecStart=/usr/local/bin/kube-apiserver \
   --service-node-port-range=30000-32767 \
   --tls-cert-file=/var/lib/kubernetes/kube-api-server.crt \
   --tls-private-key-file=/var/lib/kubernetes/kube-api-server.key \
+  --service-cluster-ip-range=10.32.0.0/24 \
   --v=2
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
Add correct SVC IP range to the api-server configuration. 

See issue https://github.com/kelseyhightower/kubernetes-the-hard-way/issues/877 for details