### PR TITLE
Fix: Remove unnecessary sed command for kubelet-config.yaml in worker…

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -14,10 +14,7 @@ for HOST in node-0 node-1; do
   sed "s|SUBNET|$SUBNET|g" \
     configs/10-bridge.conf > 10-bridge.conf
 
-  sed "s|SUBNET|$SUBNET|g" \
-    configs/kubelet-config.yaml > kubelet-config.yaml
-
-  scp 10-bridge.conf kubelet-config.yaml \
+  scp 10-bridge.conf \
   root@${HOST}:~/
 done
 ```
@@ -30,6 +27,7 @@ for HOST in node-0 node-1; do
     configs/99-loopback.conf \
     configs/containerd-config.toml \
     configs/kube-proxy-config.yaml \
+    configs/kubelet-config.yaml \
     units/containerd.service \
     units/kubelet.service \
     units/kube-proxy.service \


### PR DESCRIPTION
… node bootstrap

## Changelog


- Removed unnecessary `sed` command in `docs/09-bootstrapping-kubernetes-workers.md` that attempted to replace "SUBNET" in `configs/kubelet-config.yaml`
- Modified the `scp` command to copy the original `configs/kubelet-config.yaml` file directly without modification
- This fixes issue #886 where an unneeded sed command was identified in the worker node bootstrap section
