### PR TITLE
Fix variable substitution in smoke test curl command

### DIFF
--- a/docs/12-smoke-test.md
+++ b/docs/12-smoke-test.md
@@ -179,7 +179,7 @@ NODE_NAME=$(kubectl get pods \
 Make an HTTP request using the IP address and the `nginx` node port:
 
 ```bash
-curl -I http://${NODE_NAME}:${NODE_PORT}
+curl -I "http://${NODE_NAME}:${NODE_PORT}"
 ```
 
 ```text


### PR DESCRIPTION
The previous command used `${VAR}` syntax without quotes, which caused bash/zsh to escape the curly braces (`\${VAR}`) when pasted.
This prevented the variables from being expanded correctly.