### PR TITLE
Fix copy content 'cni-plugins' folder to worker nodes

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -39,9 +39,9 @@ done
 
 ```bash
 for HOST in node-0 node-1; do
-  scp \
-    downloads/cni-plugins/* \
-    root@${HOST}:~/cni-plugins/
+  scp -r \
+    downloads/cni-plugins/ \
+    root@${HOST}:~/
 done
 ```
 


### PR DESCRIPTION
Propose fix bash script to copy cni-plugins folder in 09-bootstrapping-kubernetes-workers.md section