### PR TITLE
Adds link to Debian 12 in prerequisites

### DIFF
--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -4,7 +4,7 @@ In this lab you will review the machine requirements necessary to follow this tu
 
 ## Virtual or Physical Machines
 
-This tutorial requires four (4) virtual or physical ARM64 or AMD64 machines running Debian 12 (bookworm). The following table lists the four machines and their CPU, memory, and storage requirements.
+This tutorial requires four (4) virtual or physical ARM64 or AMD64 machines running [Debian 12 (bookworm)](https://www.debian.org/releases/bookworm/). The following table lists the four machines and their CPU, memory, and storage requirements.
 
 | Name    | Description            | CPU | RAM   | Storage |
 |---------|------------------------|-----|-------|---------|


### PR DESCRIPTION
Added the Debian 12 to save the reader from searching for it (Debian 13 now dominates Debian's primary intro and download pages)