### PR TITLE
Remove unnecessary recursive option from rm to prevent accidental rem…

### DIFF
--- a/docs/02-jumpbox.md
+++ b/docs/02-jumpbox.md
@@ -101,7 +101,7 @@ Extract the component binaries from the release archives and organize them under
 ```
 
 ```bash
-rm -rf downloads/*gz
+rm -f downloads/*gz
 ```
 
 Make the binaries executable.


### PR DESCRIPTION
…oval of directories

No directories under downloads contain the regex pattern *gz, so this will make the removal safer and have no other impact.