### PR TITLE
fix: correct duplicate system: prefix in kube-scheduler Organization

### DIFF
--- a/ca.conf
+++ b/ca.conf
@@ -152,7 +152,7 @@ subjectKeyIdentifier = hash
 
 [kube-scheduler_distinguished_name]
 CN = system:kube-scheduler
-O  = system:system:kube-scheduler
+O  = system:kube-scheduler
 C  = US
 ST = Washington
 L  = Seattle


### PR DESCRIPTION
## Summary

- Fix typo in `ca.conf` line 155: change `system:system:kube-scheduler` to `system:kube-scheduler`
- Closes #931 

## Details

The `[kube-scheduler_distinguished_name]` section has a duplicate `system:` prefix in the Organization (O) field. This is inconsistent with other components and could cause RBAC authorization issues since Kubernetes expects the scheduler to belong to the `system:kube-scheduler` group.

## Verification

Generated CSRs before and after the fix to confirm the correct Organization:

**Before (buggy):**

```
$ openssl req -in /tmp/test-scheduler-before.csr -noout -subject
subject=CN = system:kube-scheduler, O = system:system:kube-scheduler, C = US, ST = Washington, L = Seattle
```

**After (fixed):**

```
$ openssl req -in /tmp/test-scheduler.csr -noout -subject
subject=CN = system:kube-scheduler, O = system:kube-scheduler, C = US, ST = Washington, L = Seattle
```

## Test plan

- [x] Verify the generated kube-scheduler CSR has Organization `system:kube-scheduler`
- [x] Confirm diff only touches line 155 of `ca.conf`